### PR TITLE
MAPL2.0 release

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,14 +2,14 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v1.4.0
+tag = v2.0.2
 protocol = git
 
 [ESMA_cmake]
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_cmake.git
 local_path = ./@cmake
-tag = v1.0.10
+tag = v2.1.2
 externals = Externals.cfg
 protocol = git
 
@@ -17,7 +17,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.12
+tag = v1.1.0
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 
@@ -25,14 +25,14 @@ sparse = ../../../config/GMAO_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
-tag = 1.1.13
+tag = v2.0.0
 protocol = git
 
 [FVdycoreCubed_GridComp]
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./src/Components/GEOSctm_GridComp/@FVdycoreCubed_GridComp
-tag = v1.0.9
+tag = v1.1.0
 externals = Externals.cfg
 protocol = git
 
@@ -40,14 +40,14 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/GEOSchem_GridComp.git
 local_path = ./src/Components/GEOSctm_GridComp/@GEOSchem_GridComp
-tag = v1.0.5
+tag = v1.2.0
 protocol = git
 
 [FMS]
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/orphan/v1.0.2
+tag = geos/2019.01.01
 protocol = git
 
 [externals_description]

--- a/src/Applications/GEOSctm_App/ctm_post.j
+++ b/src/Applications/GEOSctm_App/ctm_post.j
@@ -29,7 +29,7 @@ setenv ARCH `uname`
 
 setenv SITE             @SITE
 setenv GEOSBIN          @GEOSBIN
-setenv GEOSUTIL         @GEOSSRC/GMAO_Shared/GEOS_Util
+setenv GEOSUTIL         @GEOSSRC
 setenv BATCHNAME       "@POST_N"
 
 if( $?PBS_NODEFILE ) then
@@ -46,6 +46,19 @@ setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib
 #                      Perform Post Processing
 #######################################################################
 
-$GEOSUTIL/post/ctmpost.script -source @EXPDIR -ncpus $NCPUS -collections @COLLECTION -rec_plt @YYYYMM
+setenv POST_SCRIPT @EXPDIR/post/ctmpost.script.$SLURM_JOB_ID
+
+/bin/cp  $GEOSUTIL/post/gcmpost.script $POST_SCRIPT
+
+# A few simple edits change the GCM script to a CTM script:
+sed -i -e "s/gcm_run.j/ctm_run.j/g"       $POST_SCRIPT
+sed -i -e "s/GEOS5.0/GEOSctm/g"           $POST_SCRIPT
+sed -i -e "s/AGCM.rc/GEOSCTM.rc/g"        $POST_SCRIPT
+sed -i -e "s/AGCM_IM/GEOSctm_IM/g"        $POST_SCRIPT
+sed -i -e "s/AGCM_JM/GEOSctm_JM/g"        $POST_SCRIPT
+sed -i -e "s/GEOSgcm.x/GEOSctm.x/g"       $POST_SCRIPT
+sed -i -e "s/gcm_archive/ctm_archive/g"   $POST_SCRIPT
+
+$POST_SCRIPT -source @EXPDIR -ncpus $NCPUS -collections @COLLECTION -rec_plt @YYYYMM
 
 exit

--- a/src/Components/GEOSctm_GridComp/GEOS_ctmEnvGridComp.F90
+++ b/src/Components/GEOSctm_GridComp/GEOS_ctmEnvGridComp.F90
@@ -16,6 +16,7 @@
       use FV_StateMod, only : calcCourantNumberMassFlux => fv_computeMassFluxes
       use fv_arrays_mod , only: FVPRC
       use m_set_eta,  only : set_eta
+      use GEOS_FV3_UtilitiesMod, only: a2d2c
 
       implicit none
       private
@@ -920,6 +921,8 @@
       ALLOCATE( VCr8(is:ie,js:je,lm),   STAT=STATUS); VERIFY_(STATUS)
       ALLOCATE(PLEr8(is:ie,js:je,lm+1), STAT=STATUS); VERIFY_(STATUS)
 
+      call A2D2C(uc1,vc1,lm,.true.)
+      call A2D2c(uc0,vc0,lm,.true.)
       UCr8  = 0.50d0*(UC1  + UC0)
       VCr8  = 0.50d0*(VC1  + VC0)
       PLEr8 = 0.50d0*(PLE1 + PLE0)


### PR DESCRIPTION
This tag incorporates the latest MAPL-2.0 compatible repositories, matching those in the master branch of GEOSgcm as of Feb 26, 2020.   This includes Chemistry v1.2.0 which has similar capabilities to the tag Icarus-3_2_p9_CTM_MEM_16-r1 .   This tag also has improved CTM post-processing.
