### PR TITLE
March 31, 2020 - Jules Kouatchou

### DIFF
--- a/src/Applications/GEOSctm_App/ctm_run.j
+++ b/src/Applications/GEOSctm_App/ctm_run.j
@@ -21,7 +21,6 @@ umask 022
 
 limit stacksize unlimited
 
-@SETENVS
 
 #######################################################################
 # Configuration Settings
@@ -892,6 +891,8 @@ python bundleParser.py
 setenv YEAR $yearc
 ./linkbcs
 
+@SETENVS
+
 # Run GEOSctm.x
 # -------------
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh
@@ -899,7 +900,11 @@ if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh
 $RUN_CMD $NPES ./GEOSctm.x
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh
 
-set rc =  $status
+if( -e EGRESS ) then
+   set rc = 0
+else
+   set rc = -1
+endif
 
 echo GEOSctm Run Status: $rc
 

--- a/src/Applications/GEOSctm_App/ctm_setup
+++ b/src/Applications/GEOSctm_App/ctm_setup
@@ -1176,25 +1176,30 @@ else if( $MPI == mpt ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 
-   setenv MPI_COLL_REPRODUCIBLE
-   setenv SLURM_DISTRIBUTION block
+#   setenv MPI_COLL_REPRODUCIBLE
+#   setenv SLURM_DISTRIBUTION block
+#
+#   setenv MPI_XPMEM_ENABLED no
+#   setenv SUPPRESS_XPMEM_TRIM_THRESH 1
+#   setenv MPI_NUM_MEMORY_REGIONS 0
+#   
+#   #setenv MPI_DISPLAY_SETTINGS 1
+#   #setenv MPI_VERBOSE 1
+#   
+#   setenv MPI_COMM_MAX  1024
+#   setenv MPI_GROUP_MAX 1024
+#   setenv MPI_BUFS_PER_PROC 256
+#   
+#   setenv MPI_IB_TIMEOUT 23
+#
+#   # For some reason, PMI_RANK is randomly set and interferes
+#   # with binarytile.x and other executables.
+#   unsetenv PMI_RANK
 
-   setenv MPI_XPMEM_ENABLED no
-   setenv SUPPRESS_XPMEM_TRIM_THRESH 1
-   setenv MPI_NUM_MEMORY_REGIONS 0
-   
-   #setenv MPI_DISPLAY_SETTINGS 1
-   #setenv MPI_VERBOSE 1
-   
-   setenv MPI_COMM_MAX  1024
-   setenv MPI_GROUP_MAX 1024
-   setenv MPI_BUFS_PER_PROC 256
-   
-   setenv MPI_IB_TIMEOUT 23
-
-   # For some reason, PMI_RANK is randomly set and interferes
-   # with binarytile.x and other executables.
-   unsetenv PMI_RANK
+   unsetenv MPI_MEMMAP_OFF
+   unsetenv MPI_NUM_MEMORY_REGIONS
+   setenv MPI_XPMEM_ENABLED yes
+   unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
 EOF
 


### PR DESCRIPTION
ctm_setup:
  - New setting of environment variables (SETENV.commands) for the use of MPT

ctm_run.j:
  - The @SETENVS tag was placed before the MPI run command is issued.
  - Checked the exist status of the executable using the EGRESS file.