### PR TITLE
Updates for MAPL 2.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSctm
-  VERSION 2.0
+  VERSION 2.0.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.7
+  tag: v2.7.0
   develop: develop
 
 FMS:
@@ -41,7 +41,7 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/GEOSctm_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.13
+  tag: v1.2.15
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -22,7 +22,7 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.1
+  tag: v1.4.2
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 

--- a/src/Applications/GEOSctm_App/GEOSctm.F90
+++ b/src/Applications/GEOSctm_App/GEOSctm.F90
@@ -21,6 +21,7 @@ Program GEOSctm
 
    character(len=*), parameter :: Iam = 'GEOSctm'
 
+   type (MAPL_Cap) :: cap
    type (MAPL_FlapCLI) :: cli
    type (MAPL_CapOptions) :: cap_options
 

--- a/src/Applications/GEOSctm_App/GEOSctm.F90
+++ b/src/Applications/GEOSctm_App/GEOSctm.F90
@@ -20,19 +20,21 @@ Program GEOSctm
    implicit NONE
 
    character(len=*), parameter :: Iam = 'GEOSctm'
-   type (MAPL_Cap) :: cap
-   type (MAPL_FlapCapOptions) :: cap_options
+
+   type (MAPL_FlapCLI) :: cli
+   type (MAPL_CapOptions) :: cap_options
+
    integer :: status
 
 !EOP
 !----------------------------------------------------------------------
 !BOC
-   
-   cap_options = MAPL_FlapCapOptions(description = 'GEOS CTM', &
-                                     authors     = 'GMAO')
+
+   cli = MAPL_FlapCLI(description = 'GEOS CTM', & 
+                      authors     = 'GMAO')
+   cap_options = MAPL_CapOptions(cli)
    cap = MAPL_Cap('CTM', ROOT_SetServices, cap_options = cap_options)
    call cap%run(_RC)
-
 
 end program GEOSctm
 !EOC


### PR DESCRIPTION
Due to needs of partners at NOAA, MAPL 2.7.0 had a slight interface change. This PR brings the CTM so that it can work with MAPL 2.7.0.

Note to @mmanyin I also upped the version to 2.0.1 in the CMakeLists.txt. I'm working with @sdrabenh now to try and make a v10.19.1 version of GEOSgcm that's equivalent. 