### PR TITLE
Sync with GCM 10.19.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gcc-build-env:
     docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.1.0-openmpi_4.0.5-gcc_10.2.0
+      - image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v6.1.0-openmpi_4.0.5-gcc_10.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSctm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.2.1
+  tag: v3.3.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.4.2
+  tag: v3.5.0
   develop: develop
 
 ecbuild:
@@ -22,7 +22,7 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.2
+  tag: v1.4.3
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 

--- a/src/Applications/GEOSctm_App/ctm_run.j
+++ b/src/Applications/GEOSctm_App/ctm_run.j
@@ -122,19 +122,19 @@ if ( $NCPUS != NULL ) then
       @ NODES  = `echo "( ($MODEL_NPES + $NCPUS_PER_NODE) + ($CTM_IOS_NODES * $NCPUS_PER_NODE) - 1)/$NCPUS_PER_NODE" | bc`
       @ NPES   = $NODES * $NCPUS_PER_NODE
 
-        if( $NPES > $NCPUS ) then
-             echo "CPU Resources are Over-Specified"
-             echo "--------------------------------"
-             echo "Allotted NCPUs: $NCPUS"
-             echo "Requested NCPUs: $NPES"
-             echo ""
-             echo "Specified NX: $NX"
-             echo "Specified NY: $NY"
-             echo ""
-             echo "Specified IOSERVER_NODES: $CTM_IOS_NODES"
-             echo "Specified cores per node: $NCPUS_PER_NODE"
-             exit
-        endif
+      if( $NPES > $NCPUS ) then
+         echo "CPU Resources are Over-Specified"
+         echo "--------------------------------"
+         echo "Allotted NCPUs: $NCPUS"
+         echo "Requested NCPUs: $NPES"
+         echo ""
+         echo "Specified NX: $NX"
+         echo "Specified NY: $NY"
+         echo ""
+         echo "Specified IOSERVER_NODES: $CTM_IOS_NODES"
+         echo "Specified cores per node: $NCPUS_PER_NODE"
+         exit
+      endif
 
    else
 
@@ -983,11 +983,31 @@ if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 
 if( $USE_IOSERVER == 1) then
    set IOSERVER_OPTIONS = "--npes_model $MODEL_NPES --nodes_output_server $IOS_NODES"
+   set IOSERVER_EXTRA = ""
+
+   # Rome requires some extra bits for IOSERVER as it requires
+   # multigroup server with less PEs per backend node
+   if ( -x /usr/local/bin/nas_info ) then
+      set PROCTYPE=`/usr/local/bin/nas_info --nasmodel`
+      if ( $PROCTYPE == rom ) then
+         # Per Weiyuan Jiang, the ideal number of backend PEs is based on the
+         # number of HISTORY collections and number of IO nodes
+
+         # First we figure out the number of collections in the HISTORY.rc (this is not perfect, but is close to right)
+         set NUM_HIST_COLS = `cat HISTORY.rc | sed -n '/^COLLECTIONS:/,/^ *::$/{p;/^ *::$/q}' | grep -v '^ *#' | wc -l`
+
+         # Now we divide that number of collections by the ioserver nodes
+         set NUM_BACKEND_PES = `echo "scale=1;(($NUM_HIST_COLS - 1) / $IOS_NODES)" | bc | awk '{print int($1 + 0.5)}'`
+
+         set IOSERVER_EXTRA = "--oserver_type multigroup --npes_backend_pernode $NUM_BACKEND_PES"
+      endif
+   endif
 else
    set IOSERVER_OPTIONS = ""
+   set IOSERVER_EXTRA = ""
 endif
 
-$RUN_CMD $NPES ./GEOSctm.x $IOSERVER_OPTIONS --logging_config 'logging.yaml'
+$RUN_CMD $NPES ./GEOSctm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 


### PR DESCRIPTION
This PR syncs up GEOSctm with GEOSgcm v10.19.2.

Two main changes:
1. Update to Baselibs 6.2.4 and enable GFE Namespace in CMake
2. Add in some code I wrangled up to try and get things working better on the Romes at NAS.

Should be a zero-diff update, but test of course!