### PR TITLE
Update CTM to be in line with GEOSgcm 10.19.5

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -1,0 +1,38 @@
+name: Create Complete Release Tarball
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+
+      - name: Checkout mepo
+        uses: actions/checkout@v2
+        with:
+          repository: GEOS-ESM/mepo
+          path: mepo
+
+      - name: Run mepo
+        run : |
+          cd ${GITHUB_WORKSPACE}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+          ${GITHUB_WORKSPACE}/mepo/mepo clone
+
+      - name: Create tarball
+        run: |
+          tar --exclude-vcs --exclude=.mepo -cf ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.COMPLETE.tar ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+          xz -T6 ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.COMPLETE.tar
+
+      - name: Upload tarball
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.COMPLETE.tar.xz -R ${{ github.repository_owner }}/${{ github.event.repository.name }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,6 +6,7 @@ on:
     # Do not run if the only files changed cannot affect the build
     paths-ignore:
       - "**.md"
+      - "**.json"
       - "parallel_build.csh"
       - ".github/CODEOWNERS"
       - ".codebuild/**"
@@ -17,7 +18,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
+      image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -42,7 +43,6 @@ jobs:
       - name: Mepo clone external repos
         run: |
           mepo clone
-          mepo status
           mepo status
       - name: Update other branches
         if:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set (FV_PRECISION "R8" CACHE STRING "Precision of FV3 core (R4, R4R8, R8)")
 foreach (dir cmake @cmake cmake@)
   if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dir})
     list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}")
+    set (ESMA_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}" CACHE PATH "Path to ESMA_cmake code")
   endif ()
 endforeach ()
 include (esma)
@@ -63,5 +64,14 @@ install(
    DESTINATION ${CMAKE_INSTALL_PREFIX}
    )
 
-# Adds abiilty to tar source
+# Adds ability to tar source
 include (esma_cpack)
+
+# This installs a tarball of the source code
+# in the installation directory.
+# MUST BE THE LAST CODE IN THIS FILE
+option(INSTALL_SOURCE_TARFILE "Create and install source tarfile" OFF)
+if(INSTALL_SOURCE_TARFILE)
+  install(CODE "set(CMAKE_PROJECT_NAME \"${CMAKE_PROJECT_NAME}\")")
+  install(SCRIPT "${ESMA_CMAKE_PATH}/esma_postinstall.cmake")
+endif()

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ you choose.
 
 If all you wish is to build the model, you can run `parallel_build.csh` from a head node. Doing so will checkout all the external repositories of the model and build it. When done, the resulting model build will be found in `build/` and the installation will be found in `install/` with setup scripts like `ctm_setup` in `install/bin`.
 
+#### Develop Version of GEOS CTM
+
+`parallel_build.csh` provides a special flag for checking out the
+development branch of GMAO_Shared. If you run:
+
+```
+parallel_build.csh -develop
+```
+then `mepo` will run:
+
+```
+mepo develop GMAO_Shared
+```
+
 #### Debug Version of GEOS
 
 To obtain a debug version, you can run `parallel_build.csh -debug` which will build with debugging flags. This will build in `build-Debug/` and install into `install-Debug/`.
@@ -125,6 +139,20 @@ mepo clone
 The first command initializes the multi-repository and the second one
 clones and assembles all the sub-repositories according to
 `components.yaml`
+
+#### Checking out develop branches of GEOSgcm_GridComp, GEOSgcm_App, and GMAO_Shared
+
+To get the development branch of GMAO_Shared (a la
+the `-develop` flag for `parallel_build.csh`, one needs to run the
+equivalent `mepo` command. As mepo itself knows (via `components.yaml`) what the development branch of each
+subrepository is, the equivalent of `-develop` for `mepo` is to
+checkout the development branch of GMAO_Shared:
+```
+mepo develop GMAO_Shared
+```
+
+This must be done *after* `mepo clone` as it is running a git command in
+each sub-repository.
 
 #### Build the Model
 
@@ -156,6 +184,14 @@ This will install to a directory parallel to your `build` directory. If you pref
 -DCMAKE_INSTALL_PREFIX=<path>
 ```
 and CMake will install there.
+
+###### Create and install source tarfile
+
+Note that running with `parallel_build.csh` will create and install a tarfile of the source code at build time. But if CMake is run by hand, this is not the default action (as many who build with CMake by hand are developers and not often running experiments). In order to enable this at install time, add:
+```
+-DINSTALL_SOURCE_TARFILE=ON
+```
+to your CMake command.
 
 ##### Build and Install with Make
 ```

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSctm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.0
+  tag: v3.6.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.6.2
+  tag: v3.7.2
   develop: develop
 
 ecbuild:
@@ -22,14 +22,14 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10
+  tag: v1.4.11
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.8.6
+  tag: v2.12.1
   develop: develop
 
 FMS:
@@ -41,13 +41,13 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/GEOSctm_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.17
+  tag: v1.3.0
   develop: develop
 
 fvdycore:
   local: ./src/Components/GEOSctm_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.1.7
+  tag: geos/v1.2.0
   develop: geos/develop
 
 GEOSchem_GridComp:

--- a/parallel_build.csh
+++ b/parallel_build.csh
@@ -32,7 +32,7 @@ end
 
 if (-d ${ESMADIR}/@env || -d ${ESMADIR}/env@ || -d ${ESMADIR}/env) then
    if ( "$DEVELOP" == "TRUE" ) then
-      echo "Checking out development branches of GMAO_Shared"
+      echo "Checking out development branch of GMAO_Shared"
       mepo develop GMAO_Shared
    endif
 else
@@ -46,7 +46,7 @@ else
          mepo init
          mepo clone
       if ( "$DEVELOP" == "TRUE" ) then
-         echo "Checking out development branches of GEOSgcm_GridComp, GEOSgcm_App, and GMAO_Shared"
+         echo "Checking out development branch of GMAO_Shared"
          mepo develop GMAO_Shared
       endif
       endif

--- a/src/Applications/GEOSctm_App/CMakeLists.txt
+++ b/src/Applications/GEOSctm_App/CMakeLists.txt
@@ -50,6 +50,12 @@ else ()
   set(CFG_BUILT_ON_ROME FALSE)
 endif ()
 
+if(INSTALL_SOURCE_TARFILE)
+  set(CFG_INSTALL_SOURCE_TARFILE TRUE)
+else()
+  set(CFG_INSTALL_SOURCE_TARFILE FALSE)
+endif()
+
 set (setup_scripts
    ctm_setup
    )
@@ -58,7 +64,6 @@ foreach (file ${setup_scripts})
    configure_file(${file} ${file} @ONLY)
    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${file} DESTINATION bin)
 endforeach ()
-
 
 configure_file(.GEOSCTM_VERSION .GEOSCTM_VERSION @ONLY)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/.GEOSCTM_VERSION DESTINATION etc)

--- a/src/Applications/GEOSctm_App/ctm_convert.j
+++ b/src/Applications/GEOSctm_App/ctm_convert.j
@@ -85,9 +85,9 @@ set  GEOSCTM_LM = `grep  GEOSctm_LM: $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
 set     OGCM_IM = `grep      "OGCM\.IM_WORLD:" $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
 set     OGCM_JM = `grep      "OGCM\.JM_WORLD:" $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
 
->>>COUPLED<<<set  OGCM_LM  = `grep "OGCM\.LM:" $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
->>>COUPLED<<<set       NX = `grep  "OGCM\.NX:" $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
->>>COUPLED<<<set       NY = `grep  "OGCM\.NY:" $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
+@COUPLED set  OGCM_LM  = `grep "OGCM\.LM:" $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
+@COUPLED set       NX = `grep  "OGCM\.NX:" $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
+@COUPLED set       NY = `grep  "OGCM\.NY:" $HOMDIR/GEOSCTM.rc | cut -d':' -f2`
 
 # Set ATMOS and OCEAN Horizontal Resolution Tags
 # ----------------------------------------------
@@ -97,8 +97,8 @@ set OGCM_IM_Tag = `echo $OGCM_IM | awk '{printf "%4.4i", $1}'`
 set OGCM_JM_Tag = `echo $OGCM_JM | awk '{printf "%4.4i", $1}'`
 
 >>>FVCUBED<<<set ATMOStag = CF${GEOSCTM_IM_Tag}x6C
->>>DATAOCEAN<<<set OCEANtag = DE${OGCM_IM_Tag}xPE${OGCM_JM_Tag}
->>>COUPLED<<<set OCEANtag = TM${OGCM_IM_Tag}xTM${OGCM_JM_Tag}
+@DATAOCEAN set OCEANtag = DE${OGCM_IM_Tag}xPE${OGCM_JM_Tag}
+@COUPLED set OCEANtag = TM${OGCM_IM_Tag}xTM${OGCM_JM_Tag}
 
 #######################################################################
 #   Move to Scratch Directory and Copy RC Files from Home Directory
@@ -191,13 +191,13 @@ endif
 setenv BCSDIR   @BCSDIR
 setenv SSTDIR   @SSTDIR
 setenv CHMDIR   @CHMDIR
->>>DATAOCEAN<<<setenv BCRSLV    @ATMOStag_@OCEANtag
->>>COUPLED<<<setenv BCRSLV    @ATMOStag_DE0360xPE0180
+@DATAOCEAN setenv BCRSLV    @ATMOStag_@OCEANtag
+@COUPLED setenv BCRSLV    @ATMOStag_DE0360xPE0180
 setenv DATELINE DC
 
->>>COUPLED<<<setenv GRIDDIR  @COUPLEDIR/a${GEOSCTM_IM}x${GEOSCTM_JM}_o${OGCM_IM}x${OGCM_JM}
->>>COUPLED<<<setenv BCTAG `basename $GRIDDIR`
->>>DATAOCEAN<<<setenv BCTAG `basename $BCSDIR`
+@COUPLED setenv GRIDDIR  @COUPLEDIR/a${GEOSCTM_IM}x${GEOSCTM_JM}_o${OGCM_IM}x${OGCM_JM}
+@COUPLED setenv BCTAG `basename $GRIDDIR`
+@DATAOCEAN setenv BCTAG `basename $BCSDIR`
 
 >>>OSTIA<<<set YEAR = `cat cap_restart | cut -c1-4`
 
@@ -206,24 +206,24 @@ set             FILE = linkbcs
 cat << _EOF_ > $FILE
 #!/bin/csh -f
 
->>>COUPLED<<</bin/mkdir -p RESTART
+@COUPLED /bin/mkdir -p RESTART
 /bin/mkdir -p            ExtData
 /bin/ln    -sf $CHMDIR/* ExtData
 
->>>COUPLED<<</bin/ln -sf $GRIDDIR/SEAWIFS_KPAR_mon_clim.${OGCM_IM}x${OGCM_JM} SEAWIFS_KPAR_mon_clim.data
->>>COUPLED<<</bin/ln -sf $GRIDDIR/@ATMOStag_@OCEANtag-Pfafstetter.til   tile.data
->>>COUPLED<<</bin/ln -sf $GRIDDIR/@ATMOStag_@OCEANtag-Pfafstetter.TRN   runoff.bin
->>>COUPLED<<</bin/ln -sf $GRIDDIR/tripolar_${OGCM_IM}x${OGCM_JM}.ascii .
->>>COUPLED<<</bin/ln -sf $GRIDDIR/vgrid${OGCM_LM}.ascii ./vgrid.ascii
->>>COUPLED<<</bin/ln -s @COUPLEDIR/a@HIST_IMx@HIST_JM_o${OGCM_IM}x${OGCM_JM}/DC0@HIST_IMxPC0@HIST_JM_@OCEANtag-Pfafstetter.til tile_hist.data
+@COUPLED /bin/ln -sf $GRIDDIR/SEAWIFS_KPAR_mon_clim.${OGCM_IM}x${OGCM_JM} SEAWIFS_KPAR_mon_clim.data
+@COUPLED /bin/ln -sf $GRIDDIR/@ATMOStag_@OCEANtag-Pfafstetter.til   tile.data
+@COUPLED /bin/ln -sf $GRIDDIR/@ATMOStag_@OCEANtag-Pfafstetter.TRN   runoff.bin
+@COUPLED /bin/ln -sf $GRIDDIR/tripolar_${OGCM_IM}x${OGCM_JM}.ascii .
+@COUPLED /bin/ln -sf $GRIDDIR/vgrid${OGCM_LM}.ascii ./vgrid.ascii
+@COUPLED /bin/ln -s @COUPLEDIR/a@HIST_IMx@HIST_JM_o${OGCM_IM}x${OGCM_JM}/DC0@HIST_IMxPC0@HIST_JM_@OCEANtag-Pfafstetter.til tile_hist.data
 
 # Precip correction
 #/bin/ln -s /discover/nobackup/projects/gmao/share/gmao_ops/fvInput/merra_land/precip_CPCUexcludeAfrica-CMAP_corrected_MERRA/GEOSdas-2_1_4 ExtData/PCP
 
->>>DATAOCEAN<<</bin/ln -sf $BCSDIR/$BCRSLV/${BCRSLV}-Pfafstetter.til  tile.data
->>>DATAOCEAN<<<if(     -e  $BCSDIR/$BCRSLV/${BCRSLV}-Pfafstetter.TIL) then
->>>DATAOCEAN<<</bin/ln -sf $BCSDIR/$BCRSLV/${BCRSLV}-Pfafstetter.TIL  tile.bin
->>>DATAOCEAN<<<endif
+@DATAOCEAN /bin/ln -sf $BCSDIR/$BCRSLV/${BCRSLV}-Pfafstetter.til  tile.data
+@DATAOCEAN if(     -e  $BCSDIR/$BCRSLV/${BCRSLV}-Pfafstetter.TIL) then
+@DATAOCEAN /bin/ln -sf $BCSDIR/$BCRSLV/${BCRSLV}-Pfafstetter.TIL  tile.bin
+@DATAOCEAN endif
 
 # DAS or REPLAY Mode (GEOSCTM.rc:  pchem_clim_years = 1-Year Climatology)
 # --------------------------------------------------------------------
@@ -240,22 +240,22 @@ cat << _EOF_ > $FILE
 /bin/ln -sf $BCSDIR/Shared/*bin .
 /bin/ln -sf $BCSDIR/Shared/*c2l*.nc4 .
 
->>>DATAOCEAN<<</bin/ln -sf $BCSDIR/$BCRSLV/visdf_@RES_DATELINE.dat visdf.dat
->>>DATAOCEAN<<</bin/ln -sf $BCSDIR/$BCRSLV/nirdf_@RES_DATELINE.dat nirdf.dat
->>>DATAOCEAN<<</bin/ln -sf $BCSDIR/$BCRSLV/vegdyn_@RES_DATELINE.dat vegdyn.data
->>>DATAOCEAN<<</bin/ln -sf $BCSDIR/$BCRSLV/lai_clim_@RES_DATELINE.data lai.data
->>>DATAOCEAN<<</bin/ln -sf $BCSDIR/$BCRSLV/green_clim_@RES_DATELINE.data green.data
+@DATAOCEAN /bin/ln -sf $BCSDIR/$BCRSLV/visdf_@RES_DATELINE.dat visdf.dat
+@DATAOCEAN /bin/ln -sf $BCSDIR/$BCRSLV/nirdf_@RES_DATELINE.dat nirdf.dat
+@DATAOCEAN /bin/ln -sf $BCSDIR/$BCRSLV/vegdyn_@RES_DATELINE.dat vegdyn.data
+@DATAOCEAN /bin/ln -sf $BCSDIR/$BCRSLV/lai_clim_@RES_DATELINE.data lai.data
+@DATAOCEAN /bin/ln -sf $BCSDIR/$BCRSLV/green_clim_@RES_DATELINE.data green.data
 /bin/ln -sf $BCSDIR/$BCRSLV/ndvi_clim_@RES_DATELINE.data ndvi.data
 
->>>COUPLED<<<if( $OGCM_IM == 1440 ) then
->>>COUPLED<<</bin/ln -sf $GRIDDIR/ndvi.data ndvi.data
->>>COUPLED<<<endif 
+@COUPLED if( $OGCM_IM == 1440 ) then
+@COUPLED /bin/ln -sf $GRIDDIR/ndvi.data ndvi.data
+@COUPLED endif 
 
->>>COUPLED<<</bin/ln -sf $GRIDDIR/visdf.dat visdf.dat
->>>COUPLED<<</bin/ln -sf $GRIDDIR/nirdf.dat nirdf.dat
->>>COUPLED<<</bin/ln -sf $GRIDDIR/vegdyn.data vegdyn.data
->>>COUPLED<<</bin/ln -sf $GRIDDIR/lai.dat lai.data
->>>COUPLED<<</bin/ln -sf $GRIDDIR/green.dat green.data
+@COUPLED /bin/ln -sf $GRIDDIR/visdf.dat visdf.dat
+@COUPLED /bin/ln -sf $GRIDDIR/nirdf.dat nirdf.dat
+@COUPLED /bin/ln -sf $GRIDDIR/vegdyn.data vegdyn.data
+@COUPLED /bin/ln -sf $GRIDDIR/lai.dat lai.data
+@COUPLED /bin/ln -sf $GRIDDIR/green.dat green.data
 /bin/ln -sf $BCSDIR/$BCRSLV/topo_DYN_ave_@RES_DATELINE.data topo_dynave.data
 /bin/ln -sf $BCSDIR/$BCRSLV/topo_GWD_var_@RES_DATELINE.data topo_gwdvar.data
 /bin/ln -sf $BCSDIR/$BCRSLV/topo_TRB_var_@RES_DATELINE.data topo_trbvar.data
@@ -264,10 +264,10 @@ cat << _EOF_ > $FILE
 >>>FVCUBED<<</bin/ln -sf $BCSDIR/$BCRSLV/Gnomonic_$BCRSLV.dat .
 >>>FVCUBED<<<endif
 
->>>COUPLED<<<@CPEXEC $HOMDIR/*_table .
->>>COUPLED<<<@CPEXEC $GRIDDIR/INPUT/* INPUT
->>>COUPLED<<</bin/ln -sf $GRIDDIR/cice/kmt_cice.bin .
->>>COUPLED<<</bin/ln -sf $GRIDDIR/cice/grid_cice.bin .
+@COUPLED @CPEXEC $HOMDIR/*_table .
+@COUPLED @CPEXEC $GRIDDIR/INPUT/* INPUT
+@COUPLED /bin/ln -sf $GRIDDIR/cice/kmt_cice.bin .
+@COUPLED /bin/ln -sf $GRIDDIR/cice/grid_cice.bin .
 
 _EOF_
 
@@ -441,7 +441,7 @@ end
 
 @CPEXEC $FNDDIR/cap_restart $ORGDIR
 
->>>COUPLED<<<@CPEXEC $CNVDIR/RESTART/* INPUT
+@COUPLED @CPEXEC $CNVDIR/RESTART/* INPUT
 
 #######################################################################
 #             Set Experiment Run Parameters that were altered

--- a/src/Applications/GEOSctm_App/ctm_regress.j
+++ b/src/Applications/GEOSctm_App/ctm_regress.j
@@ -77,9 +77,9 @@ cd $EXPDIR/regress
 @CPEXEC $EXPDIR/GEOSctm.x   $EXPDIR/regress
 @CPEXEC $EXPDIR/linkbcs     $EXPDIR/regress
 @CPEXEC $HOMDIR/*.yaml      $EXPDIR/regress
->>>COUPLED<<<@CPEXEC $HOMDIR/*.nml       $EXPDIR/regress
->>>MOM6<<<@CPEXEC $HOMDIR/MOM_input   $EXPDIR/regress
->>>MOM6<<<@CPEXEC $HOMDIR/MOM_override $EXPDIR/regress
+@COUPLED @CPEXEC $HOMDIR/*.nml       $EXPDIR/regress
+@MOM6 @CPEXEC $HOMDIR/MOM_input   $EXPDIR/regress
+@MOM6 @CPEXEC $HOMDIR/MOM_override $EXPDIR/regress
 
 cat fvcore_layout.rc >> input.nml
 
@@ -127,8 +127,8 @@ foreach rst ( $rst_file_names )
 end
 @CPEXEC $EXPDIR/cap_restart $EXPDIR/regress
 
->>>COUPLED<<</bin/mkdir INPUT
->>>COUPLED<<<@CPEXEC $EXPDIR/RESTART/* INPUT
+@COUPLED /bin/mkdir INPUT
+@COUPLED @CPEXEC $EXPDIR/RESTART/* INPUT
 
 setenv YEAR `cat cap_restart | cut -c1-4`
 ./linkbcs
@@ -307,7 +307,7 @@ set nhmse = $date[2]
 foreach   chk ( $chk_file_names )
  /bin/mv $chk  ${chk}.${nymde}_${nhmse}.1
 end
->>>MOM6<<</bin/mv RESTART/MOM.res.nc MOM.res.nc.1
+@MOM6 /bin/mv RESTART/MOM.res.nc MOM.res.nc.1
 
 ##################################################################
 ######
@@ -317,20 +317,20 @@ end
 
 set test_duration = 180000
 
->>>DATAOCEAN<<<if( $CUBE == TRUE ) then
->>>DATAOCEAN<<<    @ test_NX = $NPES0 / 6
->>>DATAOCEAN<<<    @ test_NP = $IM / $test_NX
->>>DATAOCEAN<<<  if($test_NP < 4 ) then
->>>DATAOCEAN<<<    @ test_NX = $IM / 4 # To ensure enough gridpoints for HALO
->>>DATAOCEAN<<<  endif
->>>DATAOCEAN<<<  set test_NY = 6
->>>DATAOCEAN<<<else
->>>DATAOCEAN<<<  set test_NX = $NY0
->>>DATAOCEAN<<<  set test_NY = $NX0
->>>DATAOCEAN<<<endif
+@DATAOCEAN if( $CUBE == TRUE ) then
+@DATAOCEAN     @ test_NX = $NPES0 / 6
+@DATAOCEAN     @ test_NP = $IM / $test_NX
+@DATAOCEAN   if($test_NP < 4 ) then
+@DATAOCEAN     @ test_NX = $IM / 4 # To ensure enough gridpoints for HALO
+@DATAOCEAN   endif
+@DATAOCEAN   set test_NY = 6
+@DATAOCEAN else
+@DATAOCEAN   set test_NX = $NY0
+@DATAOCEAN   set test_NY = $NX0
+@DATAOCEAN endif
 
->>>COUPLED<<<set test_NX = $NX0
->>>COUPLED<<<set test_NY = $NY0
+@COUPLED set test_NX = $NX0
+@COUPLED set test_NY = $NY0
 
 /bin/rm              cap_restart
 echo $nymd0 $nhms0 > cap_restart
@@ -388,7 +388,7 @@ while ( $n <= $numchk )
 @ n = $n + 1
 end
 
->>>COUPLED<<<@CPEXEC RESTART/* INPUT
+@COUPLED @CPEXEC RESTART/* INPUT
 
 ##################################################################
 ######
@@ -423,17 +423,17 @@ set oldstring =  `cat GEOSCTM.rc | grep "^ *NY:"`
 set newstring =  "NY: ${test_NY}"
 /bin/mv GEOSCTM.rc GEOSCTM.tmp
 cat GEOSCTM.tmp | sed -e "s?$oldstring?$newstring?g" > GEOSCTM.rc
->>>COUPLED<<<set oldstring =  `cat GEOSCTM.rc | grep "^ *OGCM.NX:"`
->>>COUPLED<<<set newstring =  "OGCM.NX: ${test_NY}"
->>>COUPLED<<</bin/mv GEOSCTM.rc GEOSCTM.tmp
->>>COUPLED<<<cat GEOSCTM.tmp | sed -e "s?$oldstring?$newstring?g" > GEOSCTM.rc
->>>COUPLED<<<set oldstring =  `cat GEOSCTM.rc | grep "^ *OGCM.NY:"`
->>>COUPLED<<<set newstring =  "OGCM.NY: ${test_NX}"
->>>COUPLED<<</bin/mv GEOSCTM.rc GEOSCTM.tmp
->>>COUPLED<<<cat GEOSCTM.tmp | sed -e "s?$oldstring?$newstring?g" > GEOSCTM.rc
+@COUPLED set oldstring =  `cat GEOSCTM.rc | grep "^ *OGCM.NX:"`
+@COUPLED set newstring =  "OGCM.NX: ${test_NY}"
+@COUPLED /bin/mv GEOSCTM.rc GEOSCTM.tmp
+@COUPLED cat GEOSCTM.tmp | sed -e "s?$oldstring?$newstring?g" > GEOSCTM.rc
+@COUPLED set oldstring =  `cat GEOSCTM.rc | grep "^ *OGCM.NY:"`
+@COUPLED set newstring =  "OGCM.NY: ${test_NX}"
+@COUPLED /bin/mv GEOSCTM.rc GEOSCTM.tmp
+@COUPLED cat GEOSCTM.tmp | sed -e "s?$oldstring?$newstring?g" > GEOSCTM.rc
 
->>>MOM5<<<sed -r -i -e "/^ *layout/ s#= ([0-9]+),*([0-9]+)#= ${test_NY},${test_NX}#" input.nml
->>>MOM6<<<sed -r -i -e "/^ *LAYOUT/ s#= ([0-9]+), *([0-9]+)#= ${test_NY}, ${test_NX}#" MOM_input
+@MOM5 sed -r -i -e "/^ *layout/ s#= ([0-9]+),*([0-9]+)#= ${test_NY},${test_NX}#" input.nml
+@MOM6 sed -r -i -e "/^ *LAYOUT/ s#= ([0-9]+), *([0-9]+)#= ${test_NY}, ${test_NX}#" MOM_input
 
 setenv YEAR `cat cap_restart | cut -c1-4`
 ./linkbcs
@@ -449,7 +449,7 @@ set nhmse = $date[2]
 foreach   chk ( $chk_file_names )
  /bin/mv $chk  ${chk}.${nymde}_${nhmse}.2
 end
->>>MOM6<<</bin/mv RESTART/MOM.res.nc MOM.res.nc.2
+@MOM6 /bin/mv RESTART/MOM.res.nc MOM.res.nc.2
 
 #######################################################################
 #                          Compare Restarts
@@ -499,23 +499,23 @@ foreach chk ( $chk_file_names )
 end
 
 # check MOM.res.nc (MOM6 restart)
->>>MOM6<<<set file1 = MOM.res.nc.1
->>>MOM6<<<set file2 = MOM.res.nc.2
->>>MOM6<<<if( -e $file1 && -e $file2 ) then
->>>MOM6<<<                             set check = true
->>>MOM6<<<      if( $check == true ) then
->>>MOM6<<<         echo Comparing "MOM6 restarts"
->>>MOM6<<<         cmp $file1 $file2
->>>MOM6<<<         if( $status == 0 ) then
->>>MOM6<<<             echo Success!
->>>MOM6<<<             echo " "
->>>MOM6<<<         else
->>>MOM6<<<             echo Failed!
->>>MOM6<<<             echo " "
->>>MOM6<<<             set pass = false
->>>MOM6<<<         endif
->>>MOM6<<<      endif
->>>MOM6<<<endif
+@MOM6 set file1 = MOM.res.nc.1
+@MOM6 set file2 = MOM.res.nc.2
+@MOM6 if( -e $file1 && -e $file2 ) then
+@MOM6                              set check = true
+@MOM6       if( $check == true ) then
+@MOM6          echo Comparing "MOM6 restarts"
+@MOM6          cmp $file1 $file2
+@MOM6          if( $status == 0 ) then
+@MOM6              echo Success!
+@MOM6              echo " "
+@MOM6          else
+@MOM6              echo Failed!
+@MOM6              echo " "
+@MOM6              set pass = false
+@MOM6          endif
+@MOM6       endif
+@MOM6 endif
 
 @GPUEND
 

--- a/src/Applications/GEOSctm_App/ctm_setup
+++ b/src/Applications/GEOSctm_App/ctm_setup
@@ -72,7 +72,6 @@ endif
 #######################################################################
 
 # Set default behavior of switches
-set NOCVS = TRUE
 set GPU   = FALSE
 set LINKX = FALSE
 
@@ -93,11 +92,6 @@ while ( $#argv > 0 )
          set GPU = TRUE
          breaksw
 
-      # Do not archive the source
-      case --nocvs:
-         set NOCVS = TRUE
-         breaksw
-
       # Symlink GEOSctm.x
       case --link:
          set LINKX = TRUE
@@ -112,45 +106,12 @@ while ( $#argv > 0 )
 end
 
 #######################################################################
-#           CVS: Use CVS functionality only at NCCS or NAS
+#                        Determine site
 #######################################################################
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
 setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
-
-if ( $SITE != 'NCCS' && $SITE != 'NAS' ) then
-   set NOCVS = TRUE
-endif
-
-#######################################################################
-#           CVS: Test for Environment Variable
-#######################################################################
-
-if ( $?ESMA_NOCVS ) then
-   set NOCVS = TRUE
-endif
-
-#######################################################################
-#           CVS: Test if we are on a compute node
-#######################################################################
-
-if ( $NOCVS != "TRUE" ) then
-
-if ( $SITE == 'NCCS' ) then
-   if ( ($NODE =~ borg*) || ($NODE =~ warp*) ) then
-      goto ONCOMPUTE
-   endif
-   
-else if ( $SITE == 'NAS' ) then
-   if ( ($NODE =~ r[0-9]*i[0-9]*n[0-9]*) || \
-        ($NODE =~ r[0-9]*c[0-9]*t[0-9]*n[0-9]*) || \
-        ($NODE =~ maia*) ) then
-      goto ONCOMPUTE
-   endif
-endif
-
-endif
 
 #######################################################################
 #                 Test for Compiler and MPI Setup
@@ -1995,7 +1956,6 @@ foreach FILE ($FILES)
       exit 2
    endif
 
-
    sed -f $HOMDIR/sedfile $HOMDIR/tmpfile > $HOMDIR/$FILE
 
    echo "Creating ${C1}${FILE}${CN} for Experiment: $EXPID "
@@ -2559,150 +2519,31 @@ if( -e $HOMDIR/tmpfile ) /bin/rm $HOMDIR/tmpfile
 if( -e $HOMDIR/sedfile ) /bin/rm $HOMDIR/sedfile
 
 #######################################################################
-#                  Determine Experiment Specific src Files
+#                     Copy over Source Tarfile
 #######################################################################
 
-if ( $NOCVS != "TRUE" ) then
+# NOTE: This variable is set at CMake time depending on 
+#       how the build was configured.
+set INSTALL_TARFILE = @CFG_INSTALL_SOURCE_TARFILE@
+set TARFILE_NAME = "@CMAKE_PROJECT_NAME@.tar.gz"
 
-echo "ERROR! Repository managment is not supported yet in this model"
-echo "       due to the move to git. If this section is reached,"
-echo "       something has gone wrong. Please contact Matt Thompson"
-echo "       or Larry Takacs"
-exit 3
+if ( $INSTALL_TARFILE == "TRUE" ) then
 
-# Make a src directory under EXPDIR to hold current Experiment files
-# Note:  Sandbox Source Location: $GEOSDIR/src
-#        EXP TAG Source Location: $EXPDIR/src/GEOSctm/src
-# ------------------------------------------------------------------
-/bin/rm -rf ${EXPDIR}/src
-mkdir   -p  ${EXPDIR}/src/GEOSctm/src
-cd          ${EXPDIR}/src/GEOSctm/src
+   # Make a src directory under EXPDIR to hold current Experiment files
+   # ------------------------------------------------------------------
+   /bin/rm -rf ${EXPDIR}/src
+   mkdir   -p  ${EXPDIR}/src
 
-echo "${C2}Copying${CN} ${C1}Sandbox Source Code${CN} ${C2}(including non-committed files) into"
-echo "  ${CN} ${C1}${EXPDIR}/src/GEOSctm/src${CN} ${C2}...${CN}"
-# ----------------------------------------------------------------------------------------------------------------------------------
-rsync -ar  --exclude '*.o'    \
-           --exclude '*.x'    \
-           --exclude '*.xx'   \
-           --exclude '*.a'    \
-           --exclude '*.d'    \
-           --exclude '*.nc4'  \
-           --exclude '*.mod'  \
-           --exclude 'GEOSctm.x.*' \
-             ${GEOSDIR}/src/* .
-echo " "
-
-# -----------------------------------------------------------------------------
-# Create CVS TAG for Experiment
-# -----------------------------------------------------------------------------
-
-# Change Dots to Underscores in EXPID for CVS Tag
-# -----------------------------------------------
-set EXPIDTAG = `echo ${EXPID} | sed -e 's/\./_/g'`
-set tagname  = "${EXPIDTAG}__${LOGNAME}"
-
-if( ! $?ESMA_NOCOMMIT ) then
-TAGNAME:
-    echo "Enter ${C1}CVS Tag${CN} to COMMIT this Experiment (Default: ${C2}${tagname}${CN})"
-    echo "Enter ${C1}q${CN} or ${C1}quit${CN} to QUIT or SKIP the CVS COMMIT:"
-    set    TAGTMP  =  $<
-    if ( .$TAGTMP != . ) then
-       set tagname = "$TAGTMP"
-    endif
-    # Change Dots to Underscores in TAGNAME for CVS Tag
-    # -------------------------------------------------
-    set  tagname = `echo ${tagname} | sed -e 's/\./_/g'`
-    if( $tagname == 'q' | $tagname == 'quit' ) then
-        setenv ESMA_NOCOMMIT TRUE
-        set tagname = "${EXPIDTAG}__${LOGNAME}"
-        set  NUM_COMMIT_STATUS =    `/bin/ls -1 ${EXPDIR}/src | grep COMMIT_STATUS`
-        if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${EXPDIR}/src/COMMIT_STATUS_*
-        touch                                   ${EXPDIR}/src/COMMIT_STATUS_FALSE
-    else
-        set tagtest = `cvs status -v g5_modules | grep ${tagname}`
-        if( $#tagtest != 0 ) then
-            echo "      ${C1}CVS COMMIT Tag${CN} ${C2}${tagname}${CN} already exists."
-            set tagname = "${EXPIDTAG}__${LOGNAME}"
-            goto TAGNAME
-        endif
-    endif
-else
-     set  NUM_COMMIT_STATUS =    `/bin/ls -1 ${EXPDIR}/src | grep COMMIT_STATUS`
-     if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${EXPDIR}/src/COMMIT_STATUS_*
-     touch                                   ${EXPDIR}/src/COMMIT_STATUS_FALSE
-endif
-
-/bin/rm -f       ${EXPDIR}/src/GEOSctm/src/Applications/GEOSctm_App/.GEOSCTM_VERSION
-echo $tagname  > ${EXPDIR}/src/GEOSctm/src/Applications/GEOSctm_App/.GEOSCTM_VERSION
-
-
-# Create a list of non-committed Sandbox files (ignore updated files not included in sandbox)
-# -------------------------------------------------------------------------------------------
-cvs -nq upd | grep -v "U " > ${EXPDIR}/src/srcfiles
-
-
-echo "${C2}Non-Committed Sandbox Files:${CN}"
-echo "---------------------------------"
-
-/bin/rm -f ${EXPDIR}/src/cvs.log
-
-while( -e  ${EXPDIR}/src/srcfiles )
-  set file = `head -1 ${EXPDIR}/src/srcfiles`
-  set   bit = `echo "$file" | cut -c1`
-  if( "$bit" != "?" ) then
-         set  file = `echo "$file" | cut -d' ' -f2`
-        echo $file
-
-      # Local Copy of Differing Sandbox File from TAG file
-      # --------------------------------------------------
-        set newfile = `echo $file | sed -e "s?/?^?g"`
-        /bin/cp -f  ${EXPDIR}/src/GEOSctm/src/$file ${EXPDIR}/src/$newfile
-
-      # CVS Commit updated Sandbox files
-      # --------------------------------
-        if( ! $?ESMA_NOCOMMIT ) then
-                          set  branchname = "BRANCH__${tagname}"
-              cvs tag    -b  ${branchname}         $file >&  ${EXPDIR}/src/cvs.log
-              cvs upd    -r  ${branchname}         $file >&  ${EXPDIR}/src/cvs.log
-              cvs commit -m "${tagname} ${EXPDSC}" $file >&  ${EXPDIR}/src/cvs.log
-        endif
-
-  endif
-  sed 1,1d -i ${EXPDIR}/src/srcfiles
-  set  nfiles = `wc -c ${EXPDIR}/src/srcfiles | cut -d" " -f 1`
-  if( $nfiles == 0 ) /bin/rm -f ${EXPDIR}/src/srcfiles
-end
-
-echo " "
-      # Tag Final EXPDIR/src/GEOSctm/src
-      # ---------------------------------
-        if( ! $?ESMA_NOCOMMIT ) then
-              cvs tag ${tagname}  >&  ${EXPDIR}/src/cvs.log
-              if( $status == 0 ) then
-                  echo "${C2}EXP:${CN} ${C1}$EXPID${CN} ${C2}successfully committed with TAG:${CN} ${C1}${tagname}${CN}"
-                  echo "-------------------------------------------------------"
-                  set  NUM_COMMIT_STATUS =    `/bin/ls -1 ${EXPDIR}/src | grep COMMIT_STATUS`
-                  if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${EXPDIR}/src/COMMIT_STATUS_*
-                  touch                                   ${EXPDIR}/src/COMMIT_STATUS_TRUE
-              else
-                  echo "${C2}EXP:${CN} ${C1}$EXPID${CN} ${C2}failed to be committed with TAG:${CN} ${C1}${tagname}${CN}"
-                  echo "-------------------------------------------------------"
-                  set  NUM_COMMIT_STATUS =    `/bin/ls -1 ${EXPDIR}/src | grep COMMIT_STATUS`
-                  if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${EXPDIR}/src/COMMIT_STATUS_*
-                  if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${EXPDIR}/src/COMMIT_STATUS_*
-                  touch                                   ${EXPDIR}/src/COMMIT_STATUS_FALSE
-              endif
-        endif
-
-if( -e ${EXPDIR}/src/cvs.log ) /bin/rm -f ${EXPDIR}/src/cvs.log
-cd     ${EXPDIR}/src
-
-echo ""
-echo "${C2}Tarring${CN} Experiment Source Code into Single File ${C2}...${CN}"
-# ---------------------------------------------------------------------------
-/bin/tar cf ${EXPID}.GEOSctm.tar GEOSctm
-/bin/rm -r                       GEOSctm
-echo ""
+   echo "Copying Build Source Code into ${C2}${EXPDIR}/src${CN}"
+   # -----------------------------------------------------------
+   if (-e ${GEOSDEF}/src/${TARFILE_NAME}) then
+      cp ${GEOSDEF}/src/${TARFILE_NAME} ${EXPDIR}/src
+   else
+      echo "${GEOSDEF}/src/${TARFILE_NAME} not found yet CMake was asked to make and install a tarfile."
+      echo "Something went wrong."
+      exit 7
+   endif
+   echo ""
 
 endif
 
@@ -3011,149 +2852,32 @@ echo ""
 /bin/rm $COPYSCRIPT
 /bin/rm $SEDFILE
 
-# --------------------------------
-# Cloned Experiment Source Control
-# --------------------------------
+# ------------------------
+# Cloned Experiment Source
+# ------------------------
 
-if ( $NOCVS != "TRUE" ) then
+# NOTE: This variable is set at CMake time depending on 
+#       how the build was configured.
+set INSTALL_TARFILE = @CFG_INSTALL_SOURCE_TARFILE@
+set TARFILE_NAME = "@CMAKE_PROJECT_NAME@.tar.gz"
 
-echo "ERROR! Repository managment is not supported yet in this model"
-echo "       due to the move to git. If this section is reached,"
-echo "       something has gone wrong. Please contact Matt Thompson"
-echo "       or Larry Takacs"
-exit 3
+if ( $INSTALL_TARFILE == "TRUE" ) then
 
-# Make a src directory under NEWEXPDIR to hold current Experiment files
-# Note:  Sandbox Source Location: $GEOSDIR/src
-#        EXP TAG Source Location: $NEWEXPDIR/src/GEOSctm/src
-# ------------------------------------------------------------------
-/bin/rm -rf ${NEWEXPDIR}/src
-mkdir   -p  ${NEWEXPDIR}/src/GEOSctm/src
-cd          ${NEWEXPDIR}/src/GEOSctm/src
+   # Make a src directory under EXPDIR to hold current Experiment files
+   # ------------------------------------------------------------------
+   /bin/rm -rf ${NEWEXPDIR}/src
+   mkdir   -p  ${NEWEXPDIR}/src
 
-echo "${C2}Copying${CN} ${C1}Sandbox Source Code${CN} ${C2}(including non-committed files) into${CN} ${C1}${NEWEXPDIR}/src/GEOSctm/src${CN} ${C2}...${CN}"
-# ---------------------------------------------------------------------------------------------------------------------------------
-rsync -ar  --exclude '*.o'    \
-           --exclude '*.x'    \
-           --exclude '*.xx'   \
-           --exclude '*.a'    \
-           --exclude '*.d'    \
-           --exclude '*.nc4'  \
-           --exclude '*.mod'  \
-           --exclude 'GEOSctm.x.*' \
-             ${GEOSDIR}/src/* .
-echo " "
-
-# -----------------------------------------------------------------------------
-# Create CVS TAG for Experiment
-# -----------------------------------------------------------------------------
-
-# Change Dots to Underscores in NEWEXPID for CVS Tag
-# --------------------------------------------------
-set EXPIDTAG = `echo ${NEWEXPID} | sed -e 's/\./_/g'`
-set tagname  = "${EXPIDTAG}__${LOGNAME}"
-
-if( ! $?ESMA_NOCOMMIT ) then
-NEWTAGNAME:
-    echo "Enter ${C1}CVS Tag${CN} to COMMIT this Experiment (Default: ${C2}${tagname}${CN})"
-    echo "Enter ${C1}q${CN} or ${C1}quit${CN} to QUIT or SKIP the CVS COMMIT:"
-    set    TAGTMP  =  $<
-    if ( .$TAGTMP != . ) then
-       set tagname = "$TAGTMP"
-    endif
-    # Change Dots to Underscores in TAGNAME for CVS Tag
-    # -------------------------------------------------
-    set  tagname = `echo ${tagname} | sed -e 's/\./_/g'`
-    if( $tagname == 'q' | $tagname == 'quit' ) then
-        setenv ESMA_NOCOMMIT TRUE
-        set tagname = "${EXPIDTAG}__${LOGNAME}"
-        set  NUM_COMMIT_STATUS =    `/bin/ls -1 ${NEWEXPDIR}/src | grep COMMIT_STATUS`
-        if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${NEWEXPDIR}/src/COMMIT_STATUS_*
-        touch                                   ${NEWEXPDIR}/src/COMMIT_STATUS_FALSE
+   echo "Copying Build Source Code into ${C2}${NEWEXPDIR}/src${CN}"
+   # --------------------------------------------------------------
+   if (-e ${GEOSDEF}/src/${TARFILE_NAME}) then
+      cp ${GEOSDEF}/src/${TARFILE_NAME} ${NEWEXPDIR}/src
     else
-        set tagtest = `cvs status -v g5_modules | grep ${tagname}`
-        if( $#tagtest != 0 ) then
-            echo "      ${C1}CVS COMMIT Tag${CN} ${C2}${tagname}${CN} already exists."
-            set tagname = "${EXPIDTAG}__${LOGNAME}"
-            goto NEWTAGNAME
-        endif
+      echo "${GEOSDEF}/src/${TARFILE_NAME} not found yet CMake was asked to make and install a tarfile."
+      echo "Something went wrong."
+      exit 7
     endif
-else
-     set  NUM_COMMIT_STATUS =    `/bin/ls -1 ${NEWEXPDIR}/src | grep COMMIT_STATUS`
-     if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${NEWEXPDIR}/src/COMMIT_STATUS_*
-     touch                                   ${NEWEXPDIR}/src/COMMIT_STATUS_FALSE
-endif
-
-/bin/rm -f       ${NEWEXPDIR}/src/GEOSctm/src/Applications/GEOSctm_App/.GEOSCTM_VERSION
-echo $tagname  > ${NEWEXPDIR}/src/GEOSctm/src/Applications/GEOSctm_App/.GEOSCTM_VERSION
-
-
-# Create a list of non-committed Sandbox files
-# --------------------------------------------
-cvs -nq upd > ${NEWEXPDIR}/src/srcfiles
-
-
-echo "${C2}Non-Committed Sandbox Files:${CN}"
-echo "---------------------------------"
-
-/bin/rm -f ${NEWEXPDIR}/src/cvs.log
-
-while( -e  ${NEWEXPDIR}/src/srcfiles )
-  set file = `head -1 ${NEWEXPDIR}/src/srcfiles`
-  set   bit = `echo "$file" | cut -c1`
-  if( "$bit" != "?" ) then
-         set  file = `echo "$file" | cut -d' ' -f2`
-        echo $file
-
-      # Local Copy of Differing Sandbox File from TAG file
-      # --------------------------------------------------
-        set newfile = `echo $file | sed -e "s?/?^?g"`
-        /bin/cp -f  ${NEWEXPDIR}/src/GEOSctm/src/$file ${NEWEXPDIR}/src/$newfile
-
-      # CVS Commit updated Sandbox files
-      # --------------------------------
-        if( ! $?ESMA_NOCOMMIT ) then
-                          set  branchname = "BRANCH__${tagname}"
-              cvs tag    -b  ${branchname}         $file  >&  ${NEWEXPDIR}/src/cvs.log
-              cvs upd    -r  ${branchname}         $file  >&  ${NEWEXPDIR}/src/cvs.log
-              cvs commit -m "${tagname} ${EXPDSC}" $file  >&  ${NEWEXPDIR}/src/cvs.log
-        endif
-
-  endif
-  sed 1,1d -i ${NEWEXPDIR}/src/srcfiles
-  set  nfiles = `wc -c ${NEWEXPDIR}/src/srcfiles | cut -d" " -f 1`
-  if( $nfiles == 0 ) /bin/rm -f ${NEWEXPDIR}/src/srcfiles
-end
-
-echo " "
-      # Tag Final NEWEXPDIR/src/GEOSctm/src
-      # -----------------------------------
-        if( ! $?ESMA_NOCOMMIT ) then
-              cvs tag ${tagname}  >&  ${NEWEXPDIR}/src/cvs.log
-              if( $status == 0 ) then
-                  echo "${C2}EXP:${CN} ${C1}$NEWEXPID${CN} ${C2}successfully committed with TAG:${CN} ${C1}${tagname}${CN}"
-                  echo "-------------------------------------------------------"
-                  set  NUM_COMMIT_STATUS =    `/bin/ls -1 ${NEWEXPDIR}/src | grep COMMIT_STATUS`
-                  if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${NEWEXPDIR}/src/COMMIT_STATUS_*
-                  touch                                   ${NEWEXPDIR}/src/COMMIT_STATUS_TRUE
-              else
-                  echo "${C2}EXP:${CN} ${C1}$NEWEXPID${CN} ${C2}failed to be committed with TAG:${CN} ${C1}${tagname}${CN}"
-                  echo "-------------------------------------------------------"
-                  set  NUM_COMMIT_STATUS =    `/bin/ls -1 ${NEWEXPDIR}/src | grep COMMIT_STATUS`
-                  if($#NUM_COMMIT_STATUS > 0 ) /bin/rm -f ${NEWEXPDIR}/src/COMMIT_STATUS_*
-                  touch                                   ${NEWEXPDIR}/src/COMMIT_STATUS_FALSE
-              endif
-        endif
-
-/bin/rm -f ${NEWEXPDIR}/src/cvs.log
-cd         ${NEWEXPDIR}/src
-
-echo ""
-echo "${C2}Tarring${CN} Experiment Source Code into Single File ${C2}...${CN}"
-# ---------------------------------------------------------------------------
-     tar cf ${NEWEXPID}.GEOSctm.tar GEOSctm
-/bin/rm -r                          GEOSctm
-echo ""
+    echo ""
 
 endif
 
@@ -3170,25 +2894,6 @@ TRAP:
 #######################################################################
 #                      Usage and Error Outputs
 #######################################################################
-
-ONCOMPUTE:
-echo
-echo "${BOLD}${RED}            ERROR: On Compute Node ${RESET}"
-echo "${BOLD}${RED}            ====================== ${RESET}"
-
-cat << EOF
-
-ctm_setup requires access to internet resources, namely
-the CVS repository. You are attempting to run ctm_setup
-on compute node ${NODE} at ${SITE}. Please re-run on a head 
-node, or supply the --nocvs option. 
-
-For more information, contact Matt Thompson or
-Larry Takacs at GMAO.
-
-EOF
-
-exit 1
 
 CONTACTMATT:
 cat <<EOF
@@ -3239,7 +2944,7 @@ exit 1
 
 USAGE:
 cat <<EOF
-ctm_setup, a setup script for the GEOS-5 CTM
+ctm_setup, a setup script for the GEOS CTM
 
    Usage: $0:t [optional flag]
 
@@ -3249,9 +2954,7 @@ ctm_setup, a setup script for the GEOS-5 CTM
 
    If invoked alone, the script runs as normal.
 
-   For more information, please contact Larry Takacs.
-
-   Note: ctm_setup must be run on a machine with CVS access.
+   For more information, please contact Matt Thompson or Mike Manyin.
 
 EOF
 exit 1


### PR DESCRIPTION
Since #39 was just merged, I figured it's time to get in line with 10.19.5. This should be zero-diff, but I'll let @mmanyin test.

Mainly components and scripting, but there is one bit that might look interesting. I removed all the CVS bits from ctm_setup since, well, they were useless in Git land and added the new bits for the source tarfile. For more information see:

https://github.com/GEOS-ESM/GEOSgcm/issues/342

There is a chunk of text added to the README.md about this:

> ###### Create and install source tarfile
> 
> Note that running with `parallel_build.csh` will create and install a tarfile of the source code at build time. But if CMake is run by hand, this is not the default action (as many who build with CMake by hand are developers and not often running experiments). In order to enable this at install time, add:
> ```
> -DINSTALL_SOURCE_TARFILE=ON
> ```
> to your CMake command.