### PR TITLE
V2.2.0 jk

### DIFF
--- a/src/Applications/GEOSctm_App/CTM_GridComp.rc.tmpl
+++ b/src/Applications/GEOSctm_App/CTM_GridComp.rc.tmpl
@@ -1,4 +1,19 @@
 
+#---------------------------------
+# Determine if we exercise AdvCore
+#---------------------------------
+do_ctmAdvection: T
+
+#--------------------------------------------
+# Determine if we need to read PLE from files
+#--------------------------------------------
+read_PLE: F
+
+#---------------------------------------------------------
+# Determine if we need to read CX, CY, MFX, MFY from files
+#---------------------------------------------------------
+read_advCoreFields: F
+
 #---------------------------
 # Setting for Passive Tracer
 #---------------------------

--- a/src/Applications/GEOSctm_App/FPIT_ExtData.rc.tmpl
+++ b/src/Applications/GEOSctm_App/FPIT_ExtData.rc.tmpl
@@ -1,3 +1,5 @@
+Ext_AllowExtrap: .TRUE.
+
 PrimaryExports%%
 # ---------|-------------|-------|--------|----------------------|--------|--------|-------------|----------|
 #  Import  |             |       | Regrid |        Refresh       | OffSet | Scale  | Variable On |   File   |

--- a/src/Applications/GEOSctm_App/FP_ExtData.rc.tmpl
+++ b/src/Applications/GEOSctm_App/FP_ExtData.rc.tmpl
@@ -1,3 +1,5 @@
+Ext_AllowExtrap: .TRUE.
+
 PrimaryExports%%
 # ---------|-------------|-------|--------|----------------------|--------|--------|-------------|----------|
 #  Import  |             |       | Regrid |        Refresh       | OffSet | Scale  | Variable On |   File   |

--- a/src/Applications/GEOSctm_App/MERRA1_ExtData.rc.tmpl
+++ b/src/Applications/GEOSctm_App/MERRA1_ExtData.rc.tmpl
@@ -1,3 +1,5 @@
+Ext_AllowExtrap: .TRUE.
+
 PrimaryExports%%
 # ---------|-------------|-------|--------|----------------------|--------|--------|-------------|----------|
 #  Import  |             |       | Regrid |        Refresh       | OffSet | Scale  | Variable On |   File   |

--- a/src/Applications/GEOSctm_App/MERRA2_ExtData.rc.tmpl
+++ b/src/Applications/GEOSctm_App/MERRA2_ExtData.rc.tmpl
@@ -1,3 +1,5 @@
+Ext_AllowExtrap: .TRUE.
+
 PrimaryExports%%
 # ---------|-------------|-------|--------|----------------------|--------|--------|-------------|----------|
 #  Import  |             |       | Regrid |        Refresh       | OffSet | Scale  | Variable On |   File   |
@@ -117,6 +119,11 @@ DQLDT       'kg/kg/s'        N        N           0                 0.0      1.0
 #----------------
 #AdvCore Specific
 #----------------
+PS0         'Pa'             N        N           0                 0.0      1.0     PS           /discover/nobackup/projects/gmao/merra2/data/products/d5124_m2_@sMonth/Y%y4/M%m2/@MERRA2type.inst3_3d_aer_Nv.%y4%m2%d2.nc4
+PS1         'Pa'             N        N           0;@nhmsDT             0.0      1.0     PS           /discover/nobackup/projects/gmao/merra2/data/products/d5124_m2_@sMonth/Y%y4/M%m2/@MERRA2type.inst3_3d_aer_Nv.%y4%m2%d2.nc4
+DELP0       'Pa'             N        N           0                 0.0      1.0     DELP          /discover/nobackup/projects/gmao/merra2/data/products/d5124_m2_@sMonth/Y%y4/M%m2/@MERRA2type.inst3_3d_aer_Nv.%y4%m2%d2.nc4
+DELP1       'Pa'             N        N           0;@nhmsDT             0.0      1.0     DELP          /discover/nobackup/projects/gmao/merra2/data/products/d5124_m2_@sMonth/Y%y4/M%m2/@MERRA2type.inst3_3d_aer_Nv.%y4%m2%d2.nc4
+
 PLE0        'Pa'             N        N           0                 0.0      1.0     PLE	   /discover/nobackup/projects/gmao/merra2/data/products/d5124_m2_@sMonth/Y%y4/M%m2/@MERRA2type.tavg3_3d_nav_Ne.%y4%m2%d2.nc4
 PLE1        'Pa'             N	      N           0;@nhmsDT            0.0      1.0     PLE	   /discover/nobackup/projects/gmao/merra2/data/products/d5124_m2_@sMonth/Y%y4/M%m2/@MERRA2type.tavg3_3d_nav_Ne.%y4%m2%d2.nc4
 UC0;VC0     'm s-1'          N        N           0                 0.0      1.0     U;V	   /discover/nobackup/projects/gmao/merra2/data/products/d5124_m2_@sMonth/Y%y4/M%m2/@MERRA2type.inst3_3d_asm_Nv.%y4%m2%d2.nc4

--- a/src/Components/GEOSctm_GridComp/CMakeLists.txt
+++ b/src/Components/GEOSctm_GridComp/CMakeLists.txt
@@ -12,7 +12,7 @@ set (alldirs
 
 set (FV_PRECISION R8)
 esma_add_library (${this}
-  SRCS GEOS_ctmEnvGridComp.F90 GEOS_ctmGridCompMod.F90
+  SRCS GEOS_ctmEnvGridComp.F90 GEOS_ctmHistGridComp.F90 GEOS_ctmGridCompMod.F90
   SUBCOMPONENTS ${alldirs}
   DEPENDENCIES FVdycoreCubed_GridComp MAPL)
 

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CMakeLists.txt
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CMakeLists.txt
@@ -2,17 +2,12 @@
 
 if (Convection_MODE MATCHES stub)
   set (SRCS
-    CTM_ConvectionStubCompMod.F90
-    GenericConvectionMethod_mod.F90
-    GmiConvectionMethod_mod.F90
     convectiveTransport_mod.F90
     CTM_rasCalculationsMod.F90
     )
 else ()
   set (SRCS
     CTM_ConvectionGridCompMod.F90
-    GenericConvectionMethod_mod.F90
-    GmiConvectionMethod_mod.F90
     convectiveTransport_mod.F90
     CTM_rasCalculationsMod.F90
     )

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CMakeLists.txt
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CMakeLists.txt
@@ -8,6 +8,8 @@ if (Convection_MODE MATCHES stub)
 else ()
   set (SRCS
     CTM_ConvectionGridCompMod.F90
+    GmiConvectionMethod_mod.F90
+    GenericConvectionMethod_mod.F90
     convectiveTransport_mod.F90
     CTM_rasCalculationsMod.F90
     )

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CTM_ConvectionGridCompMod.F90
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CTM_ConvectionGridCompMod.F90
@@ -14,13 +14,16 @@
 !
       USE ESMF
       USE MAPL
-      USE GmiConvectionMethod_mod             ! GMI     Convection component
-      USE GenericConvectionMethod_mod         ! Generic Convection component
+      !USE GmiConvectionMethod_mod             ! GMI     Convection component
+      USE convectiveTransport_mod
       USE m_chars, ONLY : uppercase
-      use CTM_rasCalculationsMod, only : INIT_RASPARAMS, DO_RAS, RASPARAM_Type
-      USE Chem_UtilMod, only : pmaxmin
+      !USE Chem_UtilMod, only : pmaxmin
+      use GmiArrayBundlePointer_mod
+      USE GmiESMFrcFileReading_mod
 
    IMPLICIT NONE
+
+      INTEGER, PARAMETER :: DBL = KIND(0.00D+00)
    PRIVATE
 !
 ! !PUBLIC MEMBER FUNCTIONS:
@@ -38,21 +41,32 @@
 !
 !EOP
 !-------------------------------------------------------------------------
-      TYPE Convection_State
+      TYPE T_Convection_State
          PRIVATE
-         TYPE(gmiConvection_GridComp),  POINTER :: gmiCONV    => null()
-         TYPE(genConvection_GridComp),  POINTER :: genCONV    => null()
-      END TYPE Convection_State
+         logical :: det_ent      = .FALSE. ! flag for doing detrainment then entrainment
+         logical :: do_downdraft = .FALSE. ! flag for doing downdrafts
+         integer :: convecType   = 1       ! 1:  Generic Convection (only convective transport)
+                                           ! 2:  GMI convection
+         integer :: numSpecies
+         logical, pointer :: isFixedConcentration(:) => null()
+         REAL(KIND=DBL), ALLOCATABLE :: cellArea(:,:)
+         logical :: FIRST = .TRUE.
+      END TYPE T_Convection_State
     
       TYPE Convection_WRAP
-         TYPE (Convection_State), pointer :: PTR => null()
+         TYPE (T_Convection_State), pointer :: PTR => null()
       END TYPE Convection_WRAP
 
-      integer :: convecType ! 1:  Generic Convection (only convective transport)
-                            ! 2:  GMI convection
+      integer :: i1=1, i2, ig=0, im  ! dist grid indices
+      integer :: j1=1, j2, jg=0, jm  ! dist grid indices
+      integer :: km                  ! dist grid indices
+      integer :: k1=1, k2, ivert, ilong
 
-      TYPE(RASPARAM_Type) :: RASPARAMS
-      logical             :: enable_rasCalculations = .FALSE.
+      REAL, PARAMETER :: mwtAir    = 28.9
+      REAL, PARAMETER :: rStar     = 8.314E+03
+      REAL, PARAMETER :: Pa2hPa    = 0.01
+      REAL, PARAMETER :: ToGrPerKg = 1000.00
+      REAL, PARAMETER :: secPerDay = 86400.00
 
 !-------------------------------------------------------------------------
 CONTAINS
@@ -85,7 +99,7 @@ CONTAINS
       character(len=ESMF_MAXSTR)      :: rcfilen = 'CTM_GridComp.rc'
 
       type (ESMF_Config)              :: CF
-      type (Convection_State), pointer:: state   ! internal, that is
+      type (T_Convection_State), pointer:: state   ! internal, that is
       type (Convection_wrap)          :: wrap
       type (ESMF_Config)              :: convConfigFile
 
@@ -112,11 +126,9 @@ CONTAINS
 !                       ESMF Functional Services
 !                       ------------------------
 
-
       IF (MAPL_AM_I_ROOT()) THEN
          PRINT *, TRIM(Iam)//': ACTIVE'
       END IF
-
 
       !   Set the Initialize, Run, Finalize entry points
       !   ----------------------------------------------
@@ -136,9 +148,30 @@ CONTAINS
       call ESMF_ConfigLoadFile(convConfigFile, TRIM(rcfilen), rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(convConfigFile, enable_rasCalculations, &
-                          Default  = .FALSE.,                          &
-                          Label    = "enable_rasCalculations:", __RC__ )
+      call ESMF_ConfigGetAttribute(convConfigFile, state%det_ent, &
+                                   Label = "det_ent:",      &
+                                   default=.FALSE., __RC__ )
+
+      call ESMF_ConfigGetAttribute(convConfigFile, state%do_downdraft, &
+                                   Label = "do_downdraft:", &
+                                   default=.FALSE., __RC__ )
+      ! ------------------------------
+      ! convecType
+      !   1:  Generic Convection (only convective transport)
+      !   2:  GMI convection
+      !------ ------------------------
+
+      call ESMF_ConfigGetAttribute(convConfigFile, state%convecType, &
+                                   label   = "convecType:",&
+                                   default = 1, __RC__ )
+      state%FIRST = .TRUE.
+
+      IF ( MAPL_AM_I_ROOT() ) THEN
+         PRINT*," -----> det_ent      = ", state%det_ent
+         PRINT*," -----> do_downdraft = ", state%do_downdraft
+         PRINT*," -----> convecType   = ", state%convecType
+         PRINT *,"Done Reading the Convection Resource File"
+      END IF
 
 ! ========================== IMPORT STATE =========================
 
@@ -148,14 +181,6 @@ CONTAINS
            UNITS              = 'K', &
            DIMS               = MAPL_DimsHorzVert,    &
            VLOCATION          = MAPL_VLocationCenter,    __RC__ )
-
-      call MAPL_AddImportSpec(GC, &
-           SHORT_NAME         = 'Q',  &
-           LONG_NAME          = 'specific_humidity',  &
-           UNITS              = 'kg kg-1', &
-           DIMS               = MAPL_DimsHorzVert,    &
-           VLOCATION          = MAPL_VLocationCenter,    __RC__ )
-
 
       call MAPL_AddImportSpec(GC, &
            SHORT_NAME         = 'PLE',  &
@@ -185,19 +210,26 @@ CONTAINS
            DIMS               = MAPL_DimsHorzOnly,                 &
            VLOCATION          = MAPL_VLocationNone,         __RC__ )
 
-      call MAPL_AddImportSpec(GC,                                  &
-           SHORT_NAME         = 'LWI',                             &
-           LONG_NAME          = 'land-ocean-ice_mask',             &
-           UNITS              = '1',                               &
-           DIMS               = MAPL_DimsHorzOnly,                 &
-           VLOCATION          = MAPL_VLocationNone,         __RC__ )
-
       call MAPL_AddImportSpec(GC, &
            SHORT_NAME         = 'AREA',  &
            LONG_NAME          = 'agrid_cell_area',  &
            UNITS              = 'm^2', &
            DIMS               = MAPL_DimsHorzOnly,    &
            VLOCATION          = MAPL_VLocationNone,    __RC__ )
+
+      call MAPL_AddImportSpec(GC, &
+         SHORT_NAME         = 'CNV_MFC',  &
+         LONG_NAME          = 'cumulative_mass_flux',  &
+         UNITS              = 'kg m-2 s-1', &
+         DIMS               = MAPL_DimsHorzVert,    &
+         VLOCATION          = MAPL_VLocationEdge,    __RC__ )
+
+      call MAPL_AddImportSpec(GC, &
+         SHORT_NAME         = 'CNV_MFD',  &
+         LONG_NAME          = 'detraining_mass_flux',  &
+         UNITS              = 'kg m-2 s-1', &
+         DIMS               = MAPL_DimsHorzVert,    &
+         VLOCATION          = MAPL_VLocationCenter,    __RC__ )
 
       call MAPL_AddImportSpec(GC,                                  &
            SHORT_NAME         = 'ConvTR',                            &
@@ -207,62 +239,6 @@ CONTAINS
            VLOCATION          = MAPL_VLocationCenter,                &
            DATATYPE           = MAPL_BundleItem,                     &
            RESTART            = MAPL_RestartOptional,                __RC__ )
-
-      IF (enable_rasCalculations) THEN
-         call MAPL_AddImportSpec(GC,                            &
-              SHORT_NAME = 'FRLAND',                            &
-              LONG_NAME  = 'fraction_of_land',                  &
-              UNITS      = '1',                                 &
-              DIMS       = MAPL_DimsHorzOnly,                   &
-              VLOCATION  = MAPL_VLocationNone,          __RC__  )
-
-         call MAPL_AddImportSpec ( gc,                          &
-              SHORT_NAME = 'KH',                                &
-              LONG_NAME  = 'scalar_diffusivity',                &
-              UNITS      = 'm+2 s-1',                           &
-              DIMS       = MAPL_DimsHorzVert,                   &
-              VLOCATION  = MAPL_VLocationEdge,           __RC__ )
-
-         call MAPL_AddImportSpec(GC,                            &
-              SHORT_NAME = 'TS',                                &
-              LONG_NAME  = 'surface temperature',               &
-              UNITS      = 'K',                                 &
-              DIMS       = MAPL_DimsHorzOnly,                   &
-              VLOCATION  = MAPL_VLocationNone,           __RC__ )
-      ELSE
-         call MAPL_AddImportSpec(GC, &
-            SHORT_NAME         = 'CNV_MFC',  &
-            LONG_NAME          = 'cumulative_mass_flux',  &
-            UNITS              = 'kg m-2 s-1', &
-            DIMS               = MAPL_DimsHorzVert,    &
-            VLOCATION          = MAPL_VLocationEdge,    __RC__ )
-
-         call MAPL_AddImportSpec(GC, &
-            SHORT_NAME         = 'CNV_MFD',  &
-            LONG_NAME          = 'detraining_mass_flux',  &
-            UNITS              = 'kg m-2 s-1', &
-            DIMS               = MAPL_DimsHorzVert,    &
-            VLOCATION          = MAPL_VLocationCenter,    __RC__ )
-      END IF
-
-! ========================== EXPORT STATE =========================
-
-      IF (enable_rasCalculations) THEN
-         call MAPL_AddExportSpec(GC,                                 &
-              SHORT_NAME         = 'CNV_MFC',                        &
-              LONG_NAME          = 'cumulative_mass_flux',           &
-              UNITS              = 'kg m-2 s-1',                     &
-              DIMS               = MAPL_DimsHorzVert,                &
-              VLOCATION          = MAPL_VLocationEdge,        __RC__ )
-
-         call MAPL_AddExportSpec(GC,                                 &
-              SHORT_NAME         = 'CNV_MFD',                        &
-              LONG_NAME          = 'detraining_mass_flux',           &
-              UNITS              = 'kg m-2 s-1',                     &
-              DIMS               = MAPL_DimsHorzVert,                &
-              VLOCATION          = MAPL_VLocationCenter,      __RC__ )
-      ENDIF
-
 
 !#include "convTendency_ExportSpec.h"
 
@@ -313,7 +289,6 @@ CONTAINS
 !-------------------------------------------------------------------------
 !BOC
       character(len=ESMF_MAXSTR)      :: IAm = 'Initialize_'
-      character(len=ESMF_MAXSTR)      :: rcfilen = 'CTM_GridComp.rc'
       character(len=ESMF_MAXSTR)      :: COMP_NAME
 
       type(ESMF_Config)               :: CF
@@ -322,17 +297,20 @@ CONTAINS
       type(ESMF_State)                :: internal
       type(MAPL_VarSpec), pointer     :: InternalSpec(:)
       type (ESMF_Config)              :: convConfigFile
+      type (T_Convection_State), pointer:: conv_state   ! internal, that is
+      type (Convection_wrap)          :: wrap
  
       integer                         :: STATUS
       integer                         :: nymd, nhms  ! time of day
       real                            :: cdt         ! chemistry timestep (secs)
-      integer                         :: i1=1, i2, ig=0, im  ! dist grid indices
-      integer                         :: j1=1, j2, jg=0, jm  ! dist grid indices
-      integer                         :: km                  ! dist grid indices
       integer                         :: dims(3), k, l, n
-
-      type(gmiConvection_GridComp), pointer     :: gmiCONV      ! Grid Component
-      type(genConvection_GridComp), pointer     :: genCONV      ! Grid Component
+      type (ESMF_Field)               :: FIELD
+      type (ESMF_Array)               :: ARRAY
+      type (ESMF_FieldBundle)         :: ConvTR
+      REAL, POINTER, DIMENSION(:,:,:) :: S
+      character(len=ESMF_MAXSTR)      :: field_name
+      integer                         :: ic
+      REAL, POINTER, DIMENSION(:,:) :: gridBoxArea
 
       rc = 0
 
@@ -355,27 +333,17 @@ CONTAINS
       call MAPL_TimerOn(ggSTATE,"TOTAL")
       call MAPL_TimerOn(ggSTATE,"INITIALIZE")
 
-      convConfigFile = ESMF_ConfigCreate(rc=STATUS )
+      ! Get my private state from the component
+      !----------------------------------------
+
+      call ESMF_UserCompGetInternalState(gc, 'Convection_state', WRAP, STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigLoadFile(convConfigFile, TRIM(rcfilen), rc=STATUS )
-      VERIFY_(STATUS)
-
-      ! ------------------------------
-      ! convecType
-      !   1:  Generic Convection (only convective transport)
-      !   2:  GMI convection
-      !------ ------------------------
-
-      call ESMF_ConfigGetAttribute(convConfigFile, convecType, &
-                         label   = "convecType:",&
-                         default = 1, rc=STATUS )
-      VERIFY_(STATUS)
-
+      conv_state => WRAP%PTR
 
       !  Get parameters from gc and clock
       !  --------------------------------
-      call extract_ ( gc, clock, genCONV, gmiCONV, nymd, nhms, cdt, STATUS )
+      call extract_ ( gc, clock, nymd, nhms, cdt, STATUS )
       VERIFY_(STATUS)
 
       call ESMF_GridCompGet ( GC, GRID=esmfGrid, rc=STATUS)
@@ -393,42 +361,18 @@ CONTAINS
 
       ! Local sizes of three dimensions
       !--------------------------------
-      i2 = dims(1)
-      j2 = dims(2)
-      km = dims(3)
+      i2    = dims(1)
+      j2    = dims(2)
+      km    = dims(3)
+      k2    = km
+      ivert = km
+      ilong = i2-i1+1
 
-      !  Call initialize
-      !  ---------------
-      if (convecType == 1) then
-         genCONV%i1 = i1
-         genCONV%i2 = i2
-         genCONV%im = im
-         genCONV%j1 = j1
-         genCONV%j2 = j2
-         genCONV%jm = jm
-         genCONV%km = km
-
-         call initializeGenericConvection ( genCONV, impConv, expConv, nymd, nhms, &
-                        esmfGrid, cdt, STATUS )
-         VERIFY_(STATUS)
-      elseif (convecType == 2) then
-         gmiCONV%i1 = i1
-         gmiCONV%i2 = i2
-         gmiCONV%im = im
-         gmiCONV%j1 = j1
-         gmiCONV%j2 = j2
-         gmiCONV%jm = jm
-         gmiCONV%km = km
-
-         call initializeGmiConvection ( gmiCONV, impConv, expConv, nymd, nhms, &
-                        esmfGrid, cdt, STATUS )
-         VERIFY_(STATUS)
-      end if
-
-      IF (enable_rasCalculations) THEN
-         IF (MAPL_AM_I_ROOT()) PRINT*, TRIM(Iam)//': Doing RAS Calculations'
-         CALL INIT_RASPARAMS(RASPARAMS)
-      ENDIF
+      ! Grid box surface area, m^{2}
+      ! ----------------------------
+      CALL MAPL_GetPointer(impConv, gridBoxArea,    'AREA', __RC__)
+      allocate(conv_state%cellArea(i1:i2,j1:j2), STAT=STATUS); VERIFY_(STATUS)
+      conv_state%cellArea = gridBoxArea
 
       call MAPL_TimerOff(ggSTATE,"INITIALIZE")
       call MAPL_TimerOff(ggSTATE,"TOTAL")
@@ -448,7 +392,6 @@ CONTAINS
       SUBROUTINE Run_ ( gc, impConv, expConv, clock, rc )
 
 ! !USES:
-     !USE Chem_UtilMod, only : pmaxmin
 
      implicit NONE
 
@@ -480,8 +423,6 @@ CONTAINS
       integer                         :: STATUS
       character(len=ESMF_MAXSTR)      :: COMP_NAME
 
-      type(gmiConvection_GridComp), pointer     :: gmiCONV       ! Grid Component
-      type(genConvection_GridComp), pointer     :: genCONV       ! Grid Component
       integer                         :: nymd, nhms  ! time
       real                            :: cdt         ! chemistry timestep (secs)
       integer                         :: i, iOX, iT2M, k, m, n
@@ -490,10 +431,40 @@ CONTAINS
       type(ESMF_Grid)                 :: esmfGrid        
       type(ESMF_Time)                 :: TIME
       type (MAPL_MetaComp), pointer   :: ggState
+      type (T_Convection_State), pointer  :: conv_state
+      type (Convection_wrap)              :: WRAP
 
-      !REAL :: qmin, qmax
-      !real, pointer, dimension(:,:,:) ::     CNV_MFC => null()
-      !real, pointer, dimension(:,:,:) ::     CNV_MFD => null()
+      REAL, POINTER, DIMENSION(:,:)   :: zpbl
+      REAL, POINTER, DIMENSION(:,:,:) :: ple, zle, totalMass
+      REAL, POINTER, DIMENSION(:,:,:) :: CNV_MFC, CNV_MFD, T
+
+      integer :: ic, kR, ik, is
+      REAL, ALLOCATABLE :: pl(:,:,:)
+
+      REAL(KIND=DBL), ALLOCATABLE :: pbl(:,:)
+      REAL(KIND=DBL), ALLOCATABLE :: mass(:,:,:)
+      REAL(KIND=DBL), ALLOCATABLE :: press3c(:,:,:)
+      REAL(KIND=DBL), ALLOCATABLE :: press3e(:,:,:)
+      REAL(KIND=DBL), ALLOCATABLE :: gridBoxHeight(:,:,:)
+      REAL(KIND=DBL), ALLOCATABLE :: cmf(:,:,:)
+      REAL(KIND=DBL), allocatable :: dtrain       (:, :, :)
+      REAL(KIND=DBL), allocatable :: eu         (:, :, :)
+      REAL(KIND=DBL), allocatable :: ed         (:, :, :)
+      REAL(KIND=DBL), allocatable :: md         (:, :, :)
+      REAL(KIND=DBL), allocatable :: kel        (:, :, :)
+      REAL(KIND=DBL)              :: tdt
+
+      type (ESMF_Field)                   :: FIELD
+      type (ESMF_Array)                   :: ARRAY
+      type (ESMF_FieldBundle)             :: ConvTR
+      REAL, POINTER, DIMENSION(:,:,:)     :: S
+
+      type (t_GmiArrayBundle), pointer :: concentration(:)
+      character(len=ESMF_MAXSTR) :: NAME, speciesName
+      REAL :: qmin, qmax
+!EOP
+!-------------------------------------------------------------------------
+!BOC
 
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
@@ -501,35 +472,172 @@ CONTAINS
       VERIFY_(STATUS)
       Iam = TRIM(COMP_NAME)//"::Run"
 
+      ! Get my internal MAPL_Generic state
+      !-----------------------------------
+      call MAPL_GetObjectFromGC ( GC, ggState, __RC__ )
+
+      call MAPL_TimerOn(ggState,"TOTAL")
+      call MAPL_TimerOn(ggState,"RUN")
+
+      ! Get my private state from the component
+      !----------------------------------------
+      call ESMF_UserCompGetInternalState(gc, 'Convection_state', WRAP, STATUS)
+      VERIFY_(STATUS)
+
+      conv_state => WRAP%PTR
 
 !  Get ESMF parameters from gc and clock
 !  -----------------------------------------
-      call extract_ ( gc, clock, genCONV, gmiCONV, nymd, nhms, & 
-                      cdt, rc=status )
+      call extract_ ( gc, clock, nymd, nhms, cdt, rc=status )
       VERIFY_(STATUS)
-
-      IF (enable_rasCalculations) THEN
-         CALL runRAS(impConv, expConv, esmfGrid, cdt)
-
-         !call MAPL_GetPointer ( expConv,  CNV_MFC,  'CNV_MFC', __RC__ )
-         !call MAPL_GetPointer ( expConv,  CNV_MFD,  'CNV_MFD', __RC__ )
-
-         !CALL pmaxmin('CNV_MFC-:',CNV_MFC, qmin, qmax, size(CNV_MFD,1)*size(CNV_MFD,2), size(CNV_MFD,3)+1, 1. )
-         !CALL pmaxmin('CNV_MFD-:',CNV_MFD, qmin, qmax, size(CNV_MFD,1)*size(CNV_MFD,2), size(CNV_MFD,3), 1. )
-
-      ENDIF
 
 !  Run
 !  ---
-      if (convecType == 1) then
-         CALL runGenericConvection ( genCONV, impConv, expConv, nymd, nhms, &
-                          cdt, enable_rasCalculations, STATUS )
+      !---------------------
+      ! Convective Transport
+      !---------------------
+
+      ! Get the bundles containing the quantities to be diffused, 
+      !----------------------------------------------------------
+
+      call ESMF_StateGet(impConv, 'ConvTR' ,    ConvTR,     RC=STATUS)
+      VERIFY_(STATUS)
+
+      ! Identify the "fixed" tracers
+      !-----------------------------
+      IF (conv_state%FIRST) THEN
+         conv_state%FIRST = .FALSE.
+
+         call ESMF_FieldBundleGet(ConvTR, fieldCOUNT=conv_state%numSpecies, RC=STATUS)
          VERIFY_(STATUS)
-      elseif (convecType == 2) then
-         CALL runGmiConvection ( gmiCONV, impConv, expConv, nymd, nhms, &
-                          cdt, enable_rasCalculations, STATUS )
+
+         allocate(conv_state%isFixedConcentration(conv_state%numSpecies), STAT=STATUS)
          VERIFY_(STATUS)
-      end if
+         conv_state%isFixedConcentration(:) = .FALSE.
+
+         DO ic = 1, conv_state%numSpecies
+            ! Get field and name from tracer bundle
+            !--------------------------------------
+            call ESMF_FieldBundleGet(ConvTR, ic, FIELD, RC=STATUS)
+            VERIFY_(STATUS)
+
+            call ESMF_FieldGet(FIELD, name=NAME, RC=STATUS)
+            VERIFY_(STATUS)
+
+            !Identify fixed species such as O2, N2, ad.
+            if (TRIM(NAME) == 'ACET' .OR. TRIM(NAME) == 'N2'   .OR. &
+                TRIM(NAME) == 'O2'   .OR. TRIM(NAME) == 'NUMDENS')  THEN
+               conv_state%isFixedConcentration(ic) = .TRUE.
+            end if
+
+         END DO
+      END IF
+
+      ! Get the tracers from the ESMF Bundle
+      !-------------------------------------
+      ALLOCATE(concentration(conv_state%numSpecies), STAT=STATUS)
+      VERIFY_(STATUS)
+
+      DO ic = 1, conv_state%numSpecies
+         ! Get field and name from tracer bundle
+         !--------------------------------------
+         call ESMF_FieldBundleGet(ConvTR, ic, FIELD, RC=STATUS)
+         VERIFY_(STATUS)
+
+         call ESMF_FieldGet(FIELD, name=NAME, RC=STATUS)
+         VERIFY_(STATUS)
+
+         ! Get pointer to the quantity
+         !----------------------------
+         call ESMFL_BundleGetPointerToData(ConvTR, NAME, S, RC=STATUS)
+         VERIFY_(STATUS)
+
+         ! The quantity must exist; others are optional.
+         !----------------------------------------------
+         ASSERT_(associated(S ))
+
+         ALLOCATE(concentration(ic)%pArray3d(i1:i2,j1:j2,km), STAT=STATUS)
+         VERIFY_(STATUS)
+
+         concentration(ic)%pArray3d(:,:,km:1:-1) = S(:,:,:)
+      END DO
+
+      ! Satisfy the imports
+      !--------------------
+      CALL MAPL_GetPointer(impConv,          T,        'T', __RC__)
+      CALL MAPL_GetPointer(impConv,        zpbl,    'ZPBL', __RC__)
+      CALL MAPL_GetPointer(impConv,         ple,     'PLE', __RC__)
+      CALL MAPL_GetPointer(impConv,   totalMass,    'MASS', __RC__)
+      CALL MAPL_GetPointer(impConv,         zle,     'ZLE', __RC__)
+      CALL MAPL_GetPointer(impConv,     CNV_MFD, 'CNV_MFD', __RC__)
+      CALL MAPL_GetPointer(impConv,     CNV_MFC, 'CNV_MFC', __RC__)
+
+      allocate(pbl(i1:i2,j1:j2),                 STAT=STATUS); VERIFY_(STATUS)
+      allocate(press3c(i1:i2,j1:j2,k1:k2),       STAT=STATUS); VERIFY_(STATUS)
+      allocate(press3e(i1:i2,j1:j2,k1-1:k2),     STAT=STATUS); VERIFY_(STATUS)
+      ALLOCATE(pl(i1:i2,j1:j2,k1:k2),            STAT=STATUS); VERIFY_(STATUS)
+      ALLOCATE(mass(i1:i2,j1:j2,k1:k2),          STAT=STATUS); VERIFY_(STATUS)
+      allocate(gridBoxHeight(i1:i2,j1:j2,k1:k2), STAT=STATUS); VERIFY_(STATUS)
+      ALLOCATE(cmf(i1:i2,j1:j2,k1:k2),           STAT=STATUS); VERIFY_(STATUS)
+      ALLOCATE(dtrain(i1:i2,j1:j2,k1:k2),        STAT=STATUS); VERIFY_(STATUS)
+      ALLOCATE(eu(i1:i2,j1:j2,k1:k2),            STAT=STATUS); VERIFY_(STATUS)
+      ALLOCATE(ed(i1:i2,j1:j2,k1:k2),            STAT=STATUS); VERIFY_(STATUS)
+      ALLOCATE(md(i1:i2,j1:j2,k1:k2),            STAT=STATUS); VERIFY_(STATUS)
+      ALLOCATE(kel(i1:i2,j1:j2,k1:k2),           STAT=STATUS); VERIFY_(STATUS)
+
+      pbl     (:,:)       = zpbl(:,:)
+      kel     (:,:,k1:k2) = T        (:,:,km:1:-1)
+      cmf     (:,:,k1:k2) = CNV_MFC  (:,:,km-1:0:-1)
+      dtrain  (:,:,k1:k2) = CNV_MFD  (:,:,km:1:-1)
+      mass    (:,:,k1:k2) = totalMass(:,:,km:1:-1)
+      pl      (:,:,k1:k2) = (ple(:,:,0:km-1)+ple(:,:,1:km))*0.50
+
+      press3c(i1:i2,j1:j2,:)       = pl (:,:,km:1:-1)*Pa2hPa
+      press3e(i1:i2,j1:j2,k1-1:k2) = ple(:,:,km:0:-1)*Pa2hPa
+
+      ! This formulation was suggested by Steve Steentod (25Nov2014)
+      DO ik=1,km
+         kR = km-ik+1
+         eu(:,:,kR) = CNV_MFC(:,:,ik-1) - CNV_MFC(:,:,ik) + dtrain(:,:,kR)
+      END DO
+
+      ed = 0.0
+      md = 0.0
+
+      DO ik=1,km
+         kR = km-ik+1
+         gridBoxHeight(:,:,kR) = zle(:,:,ik-1)-zle(:,:,ik)         ! m
+      END DO
+
+      tdt = cdt
+
+      call doConvectiveTransport (conv_state%det_ent, conv_state%do_downdraft, pbl, cmf, &
+                      dtrain, eu, ed, md, gridBoxHeight, mass, kel, press3e,       &
+                      concentration, conv_state%isFixedConcentration, conv_state%cellArea, tdt,  &
+                      i1, i2, j1, j2, k1, k2, ilong, ivert, conv_state%numSpecies)
+
+      deallocate(pbl )
+      deallocate(dtrain, cmf, kel, eu, ed, md)
+      deallocate(press3e, press3c, mass, gridBoxHeight, pl)
+
+      ! Pass back the tracers to the ESMF Bundle
+      !------------------------------------------
+      DO ic = 1, conv_state%numSpecies
+         call ESMF_FieldBundleGet(ConvTR, ic, FIELD, RC=STATUS)
+         VERIFY_(STATUS)
+
+         call ESMF_FieldGet(FIELD, name=NAME, RC=STATUS)
+         VERIFY_(STATUS)
+
+         call ESMFL_BundleGetPointerToData(ConvTR, NAME, S, RC=STATUS)
+         VERIFY_(STATUS)
+
+         ! Do not forget to re-order the vertical levels
+         S(:,:,:) = concentration(ic)%pArray3d(:,:,km:1:-1)
+      END DO
+
+      CALL CleanArrayPointer(concentration, STATUS)
+      VERIFY_(STATUS)
 
    RETURN_(ESMF_SUCCESS)
 
@@ -575,12 +683,8 @@ CONTAINS
    integer                         :: STATUS
    character(len=ESMF_MAXSTR)      :: COMP_NAME
 
-   type(gmiConvection_GridComp), pointer     :: gmiCONV      ! Grid Component
-   type(genConvection_GridComp), pointer     :: genCONV      ! Grid Component
    integer                         :: nymd, nhms  ! time
    real                            :: cdt         ! chemistry timestep (secs)
-
-    type(Convection_state), pointer   :: state
 
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
@@ -590,192 +694,28 @@ CONTAINS
 
 !  Get ESMF parameters from gc and clock
 !  -------------------------------------
-   call extract_ ( gc, clock, genCONV, gmiCONV, nymd, nhms, cdt, STATUS, &
-                   state = state )
+   call extract_ ( gc, clock,  nymd, nhms, cdt, STATUS )
    VERIFY_(STATUS)
-
-!  Call ESMF version
-!  -----------------
-      if (convecType == 1) then
-         call finalizeGenericConvection ( genCONV )
-      elseif (convecType == 2) then
-         call finalizeGmiConvection ( gmiCONV )
-      end if
 
 !  Finalize MAPL Generic.  Atanas says, "Do not deallocate foreign objects."
 !  -------------------------------------------------------------------------
    call MAPL_GenericFinalize ( gc, impConv, expConv, clock,  RC=STATUS )
    VERIFY_(STATUS)
 
-!  Destroy Legacy state
-!  --------------------
-      if (convecType == 1) then
-         deallocate ( state%genCONV, stat = STATUS )
-         VERIFY_(STATUS)
-      elseif (convecType == 2) then
-         deallocate ( state%gmiCONV, stat = STATUS )
-         VERIFY_(STATUS)
-      end if
-
    RETURN_(ESMF_SUCCESS)
 
    END SUBROUTINE Finalize_
 !EOC
 !-------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE:  runRAS
-!
-! !INTERFACE:
-!
-      subroutine runRAS(impConv, expConv, esmfGrid, cdt)
-!
-! !USES:
-      !USE Chem_UtilMod, only : pmaxmin
-      use, intrinsic :: iso_fortran_env, only: REAL64
-
-     implicit NONE
-!
-! !INPUT PARAMETERS:
-      real,             intent(in   ) :: cdt
-!
-! !INPUT/OUTPUT PARAMETERS:
-      type(ESMF_Grid),  intent(inout) :: esmfGrid
-      type(ESMF_State), intent(inout) :: impConv     ! Import State
-      type(ESMF_State), intent(inout) :: expConv     ! Export State
-!EOP
-!-------------------------------------------------------------------------
-!BOC
-
-      character(len=ESMF_MAXSTR)      :: IAm = 'runRAS'
-      integer                         :: RC, STATUS, IM, JM, LM
-      real, pointer, dimension(:,:)   ::      FRLAND => null()
-      real, POINTER, dimension(:,:)   ::        PBLH => null() 
-      real, pointer, dimension(:,:)   ::          TS => null()
-      real, pointer, dimension(:,:,:) ::     CNV_MFC => null()
-      real, pointer, dimension(:,:,:) ::     CNV_MFD => null()
-      real, pointer, dimension(:,:,:) ::           T => null()
-      real, pointer, dimension(:,:,:) ::          TH => null()
-      real, pointer, dimension(:,:,:) ::          KH => null()
-      real, pointer, dimension(:,:,:) ::           Q => null()
-      real, pointer, dimension(:,:,:) ::         PLE => null()
-
-      real, pointer, dimension(:)     ::        PREF => null()
-      real, pointer, dimension(:,:,:) ::  CNV_MFCras => null()
-      real, pointer, dimension(:,:,:) ::  CNV_MFDras => null()
-
-      real(REAL64), pointer, dimension(:,:) :: LATS    => null()
-      real(REAL64), pointer, dimension(:,:) :: LONS    => null()
-      real(REAL64), allocatable             :: AK(:)
-      real(REAL64), allocatable             :: BK(:)
-      !REAL :: qmin, qmax
-
-         call MAPL_GetPointer ( impConv,       Q,         'Q',  __RC__ )
-         call MAPL_GetPointer ( impConv,       T,         'T',  __RC__ )
-         call MAPL_GetPointer ( impConv,      KH,        'KH',  __RC__ )
-         call MAPL_GetPointer ( impConv,      TS,        'TS',  __RC__ )
-         call MAPL_GetPointer ( impConv,     PLE,       'PLE',  __RC__ )
-         call MAPL_GetPointer ( impConv,    PBLH,      'ZPBL',  __RC__ )
-         call MAPL_GetPointer ( impConv,  FRLAND,    'FRLAND',  __RC__ )
-
-         IM = SIZE(T, 1)
-         JM = SIZE(T, 2)
-         LM = SIZE(T, 3)
-
-         ! Get the AK and BK
-         allocate(AK(LM+1),stat=status)
-         VERIFY_(STATUS)
-         allocate(BK(LM+1),stat=status)
-         VERIFY_(STATUS)
-
-         call ESMF_AttributeGet(esmfGrid,name="GridAK",valuelist=AK,rc=status)
-         VERIFY_(STATUS)
-         call ESMF_AttributeGet(esmfGrid,name="GridBK",valuelist=BK,rc=status)
-         VERIFY_(STATUS)
-
-         ! Get the LATS and LONS
-         call ESMF_GridGetCoord(esmfGrid, coordDim=2, localDE=0, &
-                                staggerloc=ESMF_STAGGERLOC_CENTER, &
-                                farrayPtr=LATS, rc=status)
-         VERIFY_(status)
-
-         call ESMF_GridGetCoord(esmfGrid, coordDim=1, localDE=0, &
-                                staggerloc=ESMF_STAGGERLOC_CENTER, &
-                                farrayPtr=LONS, rc=status)
-
-         !-----------------------------------------
-         ! Compute the reference air pressure in Pa
-         ! AK in Pa
-         ! MAPL_P00 = 100000 Pa
-         !-----------------------------------------
-         ALLOCATE(PREF(LM+1))
-         PREF = AK + BK * MAPL_P00
-
-         ALLOCATE(TH        (IM,JM,1:LM))
-         ALLOCATE(CNV_MFDras(IM,JM,1:LM))
-         ALLOCATE(CNV_MFCras(IM,JM,0:LM))
-
-         ! Compute the potential temperature
-         TH(:,:,:) = T(:,:,:)/ &
-                     ((0.5*(PLE(:,:,0:LM-1) +  PLE(:,:,1:LM  ) ))/100000.)**(MAPL_RGAS/MAPL_CP)
-
-!         IF ( MAPL_am_I_root() ) THEN
-!            PRINT*, "DT: ", cdt
-!            PRINT*
-!            PRINT*, "AK: ", AK
-!            PRINT*
-!            PRINT*, "BK: ", BK
-!            PRINT*
-!            PRINT*, "PREF: ", PREF
-!            PRINT*
-!         END IF
-!
-!         CALL pmaxmin('LONS :',REAL(LONS), qmin, qmax, IM*JM,    1, 1. )
-!         CALL pmaxmin('LATS :',REAL(LATS), qmin, qmax, IM*JM,    1, 1. )
-!         CALL pmaxmin('KH :',        KH, qmin, qmax, IM*JM, LM+1, 1. )
-!         CALL pmaxmin('TH :',        TH, qmin, qmax, IM*JM, LM  , 1. )
-!         CALL pmaxmin('TS :',        TS, qmin, qmax, IM*JM,    1, 1. )
-!         CALL pmaxmin('Q  :',         Q, qmin, qmax, IM*JM, LM  , 1. )
-!         CALL pmaxmin('FRLAND:', FRLAND, qmin, qmax, IM*JM,    1, 1. )
-!         CALL pmaxmin('PLE :',      PLE, qmin, qmax, IM*JM, LM+1, 1. )
-!         CALL pmaxmin('PBLH :',    PBLH, qmin, qmax, IM*JM,    1, 1. )
-!
-         ! Do the RAS calculations to obtain the values of CNV_MFD and CNV_MFC
-         CALL DO_RAS(RASPARAMS, PREF, TH, PLE, KH, PBLH, Q, &
-                     FRLAND, TS, CNV_MFDras, CNV_MFCras,      &
-                     REAL(LATS), REAL(LONS), cdt, IM, JM, LM)
-
-         !CALL pmaxmin('CNV_MFC :',CNV_MFCras, qmin, qmax, IM*JM, LM+1, 1. )
-         !CALL pmaxmin('CNV_MFD :',CNV_MFDras, qmin, qmax, IM*JM, LM, 1. )
-
-         ! Populate the export state
-         call MAPL_GetPointer ( expConv,  CNV_MFC,  'CNV_MFC', ALLOC=.TRUE., __RC__ )
-         call MAPL_GetPointer ( expConv,  CNV_MFD,  'CNV_MFD', ALLOC=.TRUE., __RC__ )
-
-         CNV_MFC(:,:,:) = CNV_MFCras(:,:,:)
-         CNV_MFD(:,:,:) = CNV_MFDras(:,:,:)
-
-         DEALLOCATE(PREF)
-         DEALLOCATE(CNV_MFDras, CNV_MFCras)
-         DEALLOCATE(TH)
-         deallocate(AK, BK)
-      end subroutine runRAS
-!EOC
-!-------------------------------------------------------------------------
-    SUBROUTINE extract_ ( gc, clock, genCONV, gmiCONV, nymd, nhms, cdt, &
-                          rc, state )
+    SUBROUTINE extract_ ( gc, clock, nymd, nhms, cdt, rc )
 
     type(ESMF_GridComp), intent(inout) :: gc
     type(ESMF_Clock), intent(in)       :: clock
-    type(gmiConvection_GridComp), pointer :: gmiCONV
-    type(genConvection_GridComp), pointer :: genCONV
     integer, intent(out)               :: nymd, nhms
     real, intent(out)                  :: cdt
     integer, intent(out)               :: rc
-    type(Convection_state), pointer, optional   :: state
 
-
-    type(Convection_state), pointer    :: myState
+    type(T_Convection_state), pointer    :: myState
 
 !   ErrLog Variables
 !   ----------------
@@ -785,7 +725,6 @@ CONTAINS
 
     type(ESMF_Time)      :: TIME
     type(ESMF_Config)    :: CF
-    type(Convection_Wrap)  :: wrap
     integer              :: IYR, IMM, IDD, IHR, IMN, ISC
 
 
@@ -794,35 +733,6 @@ CONTAINS
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, RC=STATUS )
     VERIFY_(STATUS)
     Iam = trim(COMP_NAME) // 'extract_'
-
-    rc = 0
-
-!   Get my internal state
-!   ---------------------
-    call ESMF_UserCompGetInternalState(gc, 'Convection_state', WRAP, STATUS)
-    VERIFY_(STATUS)
-    myState => wrap%ptr
-    if ( present(state) ) then
-         state => wrap%ptr
-    end if
-
-!   This is likely to be allocated during initialize only
-!   -----------------------------------------------------
-      if (convecType == 1) then
-         if ( .not. associated(myState%genCONV) ) then
-              allocate ( myState%genCONV, stat=STATUS )
-              VERIFY_(STATUS)
-         end if
-
-         genCONV  => myState%genCONV
-      elseif (convecType == 2) then
-         if ( .not. associated(myState%gmiCONV) ) then
-              allocate ( myState%gmiCONV, stat=STATUS )
-              VERIFY_(STATUS)
-         end if
-
-         gmiCONV  => myState%gmiCONV
-      end if
 
 !   Get the configuration
 !   ---------------------
@@ -833,11 +743,6 @@ CONTAINS
 !   -------------
     call ESMF_ConfigGetAttribute ( CF, cdt, LABEL="RUN_DT:", RC=STATUS )
     VERIFY_(STATUS)
-
-!   Disable Option for Modified cdt (Chemistry does not operate with modified refresh intervals)
-!   --------------------------------------------------------------------------------------------
-!   call ESMF_ConfigGetAttribute ( CF, cdt, LABEL="CHEMISTRY_DT:", DEFAULT=cdt, RC=STATUS )
-!   VERIFY_(STATUS)
 
 !   Extract nymd, nhms, day of year from clock
 !   ------------------------------------------

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CTM_ConvectionGridCompMod.F90
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CTM_ConvectionGridCompMod.F90
@@ -14,16 +14,11 @@
 !
       USE ESMF
       USE MAPL
-      !USE GmiConvectionMethod_mod             ! GMI     Convection component
-      USE convectiveTransport_mod
+      USE GmiConvectionMethod_mod             ! GMI     Convection component
+      USE GenericConvectionMethod_mod         ! Generic Convection component
       USE m_chars, ONLY : uppercase
-      !USE Chem_UtilMod, only : pmaxmin
-      use GmiArrayBundlePointer_mod
-      USE GmiESMFrcFileReading_mod
 
    IMPLICIT NONE
-
-      INTEGER, PARAMETER :: DBL = KIND(0.00D+00)
    PRIVATE
 !
 ! !PUBLIC MEMBER FUNCTIONS:
@@ -39,35 +34,21 @@
 !
 !  07Dec2012  Kouatchou  Created the Convection stub.
 !
-!EOP
-!-------------------------------------------------------------------------
       TYPE T_Convection_State
          PRIVATE
-         logical :: det_ent      = .FALSE. ! flag for doing detrainment then entrainment
-         logical :: do_downdraft = .FALSE. ! flag for doing downdrafts
+         TYPE(gmiConvection_GridComp),  POINTER :: gmiCONV    => null()
+         TYPE(genConvection_GridComp),  POINTER :: genCONV    => null()
          integer :: convecType   = 1       ! 1:  Generic Convection (only convective transport)
                                            ! 2:  GMI convection
-         integer :: numSpecies
-         logical, pointer :: isFixedConcentration(:) => null()
-         REAL(KIND=DBL), ALLOCATABLE :: cellArea(:,:)
-         logical :: FIRST = .TRUE.
+         logical :: FIRST
       END TYPE T_Convection_State
     
-      TYPE Convection_WRAP
+      TYPE T_Convection_WRAP
          TYPE (T_Convection_State), pointer :: PTR => null()
-      END TYPE Convection_WRAP
+      END TYPE T_Convection_WRAP
 
-      integer :: i1=1, i2, ig=0, im  ! dist grid indices
-      integer :: j1=1, j2, jg=0, jm  ! dist grid indices
-      integer :: km                  ! dist grid indices
-      integer :: k1=1, k2, ivert, ilong
 
-      REAL, PARAMETER :: mwtAir    = 28.9
-      REAL, PARAMETER :: rStar     = 8.314E+03
-      REAL, PARAMETER :: Pa2hPa    = 0.01
-      REAL, PARAMETER :: ToGrPerKg = 1000.00
-      REAL, PARAMETER :: secPerDay = 86400.00
-
+!EOP
 !-------------------------------------------------------------------------
 CONTAINS
 !-------------------------------------------------------------------------
@@ -100,7 +81,7 @@ CONTAINS
 
       type (ESMF_Config)              :: CF
       type (T_Convection_State), pointer:: state   ! internal, that is
-      type (Convection_wrap)          :: wrap
+      type (T_Convection_wrap)          :: wrap
       type (ESMF_Config)              :: convConfigFile
 
       integer                         :: STATUS
@@ -126,9 +107,11 @@ CONTAINS
 !                       ESMF Functional Services
 !                       ------------------------
 
+
       IF (MAPL_AM_I_ROOT()) THEN
          PRINT *, TRIM(Iam)//': ACTIVE'
       END IF
+
 
       !   Set the Initialize, Run, Finalize entry points
       !   ----------------------------------------------
@@ -148,13 +131,6 @@ CONTAINS
       call ESMF_ConfigLoadFile(convConfigFile, TRIM(rcfilen), rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(convConfigFile, state%det_ent, &
-                                   Label = "det_ent:",      &
-                                   default=.FALSE., __RC__ )
-
-      call ESMF_ConfigGetAttribute(convConfigFile, state%do_downdraft, &
-                                   Label = "do_downdraft:", &
-                                   default=.FALSE., __RC__ )
       ! ------------------------------
       ! convecType
       !   1:  Generic Convection (only convective transport)
@@ -167,11 +143,12 @@ CONTAINS
       state%FIRST = .TRUE.
 
       IF ( MAPL_AM_I_ROOT() ) THEN
-         PRINT*," -----> det_ent      = ", state%det_ent
-         PRINT*," -----> do_downdraft = ", state%do_downdraft
+         !PRINT*," -----> det_ent      = ", state%det_ent
+         !PRINT*," -----> do_downdraft = ", state%do_downdraft
          PRINT*," -----> convecType   = ", state%convecType
          PRINT *,"Done Reading the Convection Resource File"
       END IF
+
 
 ! ========================== IMPORT STATE =========================
 
@@ -181,6 +158,14 @@ CONTAINS
            UNITS              = 'K', &
            DIMS               = MAPL_DimsHorzVert,    &
            VLOCATION          = MAPL_VLocationCenter,    __RC__ )
+
+      call MAPL_AddImportSpec(GC, &
+           SHORT_NAME         = 'Q',  &
+           LONG_NAME          = 'specific_humidity',  &
+           UNITS              = 'kg kg-1', &
+           DIMS               = MAPL_DimsHorzVert,    &
+           VLOCATION          = MAPL_VLocationCenter,    __RC__ )
+
 
       call MAPL_AddImportSpec(GC, &
            SHORT_NAME         = 'PLE',  &
@@ -210,6 +195,13 @@ CONTAINS
            DIMS               = MAPL_DimsHorzOnly,                 &
            VLOCATION          = MAPL_VLocationNone,         __RC__ )
 
+      call MAPL_AddImportSpec(GC,                                  &
+           SHORT_NAME         = 'LWI',                             &
+           LONG_NAME          = 'land-ocean-ice_mask',             &
+           UNITS              = '1',                               &
+           DIMS               = MAPL_DimsHorzOnly,                 &
+           VLOCATION          = MAPL_VLocationNone,         __RC__ )
+
       call MAPL_AddImportSpec(GC, &
            SHORT_NAME         = 'AREA',  &
            LONG_NAME          = 'agrid_cell_area',  &
@@ -218,18 +210,18 @@ CONTAINS
            VLOCATION          = MAPL_VLocationNone,    __RC__ )
 
       call MAPL_AddImportSpec(GC, &
-         SHORT_NAME         = 'CNV_MFC',  &
-         LONG_NAME          = 'cumulative_mass_flux',  &
-         UNITS              = 'kg m-2 s-1', &
-         DIMS               = MAPL_DimsHorzVert,    &
-         VLOCATION          = MAPL_VLocationEdge,    __RC__ )
+           SHORT_NAME         = 'CNV_MFC',  &
+           LONG_NAME          = 'cumulative_mass_flux',  &
+           UNITS              = 'kg m-2 s-1', &
+           DIMS               = MAPL_DimsHorzVert,    &
+           VLOCATION          = MAPL_VLocationEdge,    __RC__ )
 
       call MAPL_AddImportSpec(GC, &
-         SHORT_NAME         = 'CNV_MFD',  &
-         LONG_NAME          = 'detraining_mass_flux',  &
-         UNITS              = 'kg m-2 s-1', &
-         DIMS               = MAPL_DimsHorzVert,    &
-         VLOCATION          = MAPL_VLocationCenter,    __RC__ )
+           SHORT_NAME         = 'CNV_MFD',  &
+           LONG_NAME          = 'detraining_mass_flux',  &
+           UNITS              = 'kg m-2 s-1', &
+           DIMS               = MAPL_DimsHorzVert,    &
+           VLOCATION          = MAPL_VLocationCenter,    __RC__ )
 
       call MAPL_AddImportSpec(GC,                                  &
            SHORT_NAME         = 'ConvTR',                            &
@@ -289,6 +281,7 @@ CONTAINS
 !-------------------------------------------------------------------------
 !BOC
       character(len=ESMF_MAXSTR)      :: IAm = 'Initialize_'
+      character(len=ESMF_MAXSTR)      :: rcfilen = 'CTM_GridComp.rc'
       character(len=ESMF_MAXSTR)      :: COMP_NAME
 
       type(ESMF_Config)               :: CF
@@ -298,19 +291,18 @@ CONTAINS
       type(MAPL_VarSpec), pointer     :: InternalSpec(:)
       type (ESMF_Config)              :: convConfigFile
       type (T_Convection_State), pointer:: conv_state   ! internal, that is
-      type (Convection_wrap)          :: wrap
+      type (T_Convection_wrap)          :: wrap
  
       integer                         :: STATUS
       integer                         :: nymd, nhms  ! time of day
       real                            :: cdt         ! chemistry timestep (secs)
+      integer                         :: i1=1, i2, ig=0, im  ! dist grid indices
+      integer                         :: j1=1, j2, jg=0, jm  ! dist grid indices
+      integer                         :: km                  ! dist grid indices
       integer                         :: dims(3), k, l, n
-      type (ESMF_Field)               :: FIELD
-      type (ESMF_Array)               :: ARRAY
-      type (ESMF_FieldBundle)         :: ConvTR
-      REAL, POINTER, DIMENSION(:,:,:) :: S
-      character(len=ESMF_MAXSTR)      :: field_name
-      integer                         :: ic
-      REAL, POINTER, DIMENSION(:,:) :: gridBoxArea
+
+      type(gmiConvection_GridComp), pointer     :: gmiCONV      ! Grid Component
+      type(genConvection_GridComp), pointer     :: genCONV      ! Grid Component
 
       rc = 0
 
@@ -330,9 +322,6 @@ CONTAINS
       call MAPL_GenericInitialize ( gc, impConv, expConv, clock,  RC=STATUS )
       VERIFY_(STATUS)
 
-      call MAPL_TimerOn(ggSTATE,"TOTAL")
-      call MAPL_TimerOn(ggSTATE,"INITIALIZE")
-
       ! Get my private state from the component
       !----------------------------------------
 
@@ -341,9 +330,13 @@ CONTAINS
 
       conv_state => WRAP%PTR
 
+      call MAPL_TimerOn(ggSTATE,"TOTAL")
+      call MAPL_TimerOn(ggSTATE,"INITIALIZE")
+
+
       !  Get parameters from gc and clock
       !  --------------------------------
-      call extract_ ( gc, clock, nymd, nhms, cdt, STATUS )
+      call extract_ ( gc, clock, genCONV, gmiCONV, nymd, nhms, cdt, STATUS )
       VERIFY_(STATUS)
 
       call ESMF_GridCompGet ( GC, GRID=esmfGrid, rc=STATUS)
@@ -361,18 +354,37 @@ CONTAINS
 
       ! Local sizes of three dimensions
       !--------------------------------
-      i2    = dims(1)
-      j2    = dims(2)
-      km    = dims(3)
-      k2    = km
-      ivert = km
-      ilong = i2-i1+1
+      i2 = dims(1)
+      j2 = dims(2)
+      km = dims(3)
 
-      ! Grid box surface area, m^{2}
-      ! ----------------------------
-      CALL MAPL_GetPointer(impConv, gridBoxArea,    'AREA', __RC__)
-      allocate(conv_state%cellArea(i1:i2,j1:j2), STAT=STATUS); VERIFY_(STATUS)
-      conv_state%cellArea = gridBoxArea
+      !  Call initialize
+      !  ---------------
+      if (conv_state%convecType == 1) then
+         genCONV%i1 = i1
+         genCONV%i2 = i2
+         genCONV%im = im
+         genCONV%j1 = j1
+         genCONV%j2 = j2
+         genCONV%jm = jm
+         genCONV%km = km
+
+         call initializeGenericConvection ( genCONV, impConv, expConv, nymd, nhms, &
+                        esmfGrid, cdt, STATUS )
+         VERIFY_(STATUS)
+      elseif (conv_state%convecType == 2) then
+         gmiCONV%i1 = i1
+         gmiCONV%i2 = i2
+         gmiCONV%im = im
+         gmiCONV%j1 = j1
+         gmiCONV%j2 = j2
+         gmiCONV%jm = jm
+         gmiCONV%km = km
+
+         call initializeGmiConvection ( gmiCONV, impConv, expConv, nymd, nhms, &
+                        esmfGrid, cdt, STATUS )
+         VERIFY_(STATUS)
+      end if
 
       call MAPL_TimerOff(ggSTATE,"INITIALIZE")
       call MAPL_TimerOff(ggSTATE,"TOTAL")
@@ -392,6 +404,7 @@ CONTAINS
       SUBROUTINE Run_ ( gc, impConv, expConv, clock, rc )
 
 ! !USES:
+     !USE Chem_UtilMod, only : pmaxmin
 
      implicit NONE
 
@@ -423,6 +436,8 @@ CONTAINS
       integer                         :: STATUS
       character(len=ESMF_MAXSTR)      :: COMP_NAME
 
+      type(gmiConvection_GridComp), pointer     :: gmiCONV       ! Grid Component
+      type(genConvection_GridComp), pointer     :: genCONV       ! Grid Component
       integer                         :: nymd, nhms  ! time
       real                            :: cdt         ! chemistry timestep (secs)
       integer                         :: i, iOX, iT2M, k, m, n
@@ -432,39 +447,7 @@ CONTAINS
       type(ESMF_Time)                 :: TIME
       type (MAPL_MetaComp), pointer   :: ggState
       type (T_Convection_State), pointer  :: conv_state
-      type (Convection_wrap)              :: WRAP
-
-      REAL, POINTER, DIMENSION(:,:)   :: zpbl
-      REAL, POINTER, DIMENSION(:,:,:) :: ple, zle, totalMass
-      REAL, POINTER, DIMENSION(:,:,:) :: CNV_MFC, CNV_MFD, T
-
-      integer :: ic, kR, ik, is
-      REAL, ALLOCATABLE :: pl(:,:,:)
-
-      REAL(KIND=DBL), ALLOCATABLE :: pbl(:,:)
-      REAL(KIND=DBL), ALLOCATABLE :: mass(:,:,:)
-      REAL(KIND=DBL), ALLOCATABLE :: press3c(:,:,:)
-      REAL(KIND=DBL), ALLOCATABLE :: press3e(:,:,:)
-      REAL(KIND=DBL), ALLOCATABLE :: gridBoxHeight(:,:,:)
-      REAL(KIND=DBL), ALLOCATABLE :: cmf(:,:,:)
-      REAL(KIND=DBL), allocatable :: dtrain       (:, :, :)
-      REAL(KIND=DBL), allocatable :: eu         (:, :, :)
-      REAL(KIND=DBL), allocatable :: ed         (:, :, :)
-      REAL(KIND=DBL), allocatable :: md         (:, :, :)
-      REAL(KIND=DBL), allocatable :: kel        (:, :, :)
-      REAL(KIND=DBL)              :: tdt
-
-      type (ESMF_Field)                   :: FIELD
-      type (ESMF_Array)                   :: ARRAY
-      type (ESMF_FieldBundle)             :: ConvTR
-      REAL, POINTER, DIMENSION(:,:,:)     :: S
-
-      type (t_GmiArrayBundle), pointer :: concentration(:)
-      character(len=ESMF_MAXSTR) :: NAME, speciesName
-      REAL :: qmin, qmax
-!EOP
-!-------------------------------------------------------------------------
-!BOC
+      type (T_Convection_wrap)              :: WRAP
 
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
@@ -486,158 +469,24 @@ CONTAINS
 
       conv_state => WRAP%PTR
 
+
 !  Get ESMF parameters from gc and clock
 !  -----------------------------------------
-      call extract_ ( gc, clock, nymd, nhms, cdt, rc=status )
+      call extract_ ( gc, clock, genCONV, gmiCONV, nymd, nhms, & 
+                      cdt, rc=status )
       VERIFY_(STATUS)
 
 !  Run
 !  ---
-      !---------------------
-      ! Convective Transport
-      !---------------------
-
-      ! Get the bundles containing the quantities to be diffused, 
-      !----------------------------------------------------------
-
-      call ESMF_StateGet(impConv, 'ConvTR' ,    ConvTR,     RC=STATUS)
-      VERIFY_(STATUS)
-
-      ! Identify the "fixed" tracers
-      !-----------------------------
-      IF (conv_state%FIRST) THEN
-         conv_state%FIRST = .FALSE.
-
-         call ESMF_FieldBundleGet(ConvTR, fieldCOUNT=conv_state%numSpecies, RC=STATUS)
+      if (conv_state%convecType == 1) then
+         CALL runGenericConvection ( genCONV, impConv, expConv, nymd, nhms, &
+                          cdt, STATUS )
          VERIFY_(STATUS)
-
-         allocate(conv_state%isFixedConcentration(conv_state%numSpecies), STAT=STATUS)
+      elseif (conv_state%convecType == 2) then
+         CALL runGmiConvection ( gmiCONV, impConv, expConv, nymd, nhms, &
+                          cdt, STATUS )
          VERIFY_(STATUS)
-         conv_state%isFixedConcentration(:) = .FALSE.
-
-         DO ic = 1, conv_state%numSpecies
-            ! Get field and name from tracer bundle
-            !--------------------------------------
-            call ESMF_FieldBundleGet(ConvTR, ic, FIELD, RC=STATUS)
-            VERIFY_(STATUS)
-
-            call ESMF_FieldGet(FIELD, name=NAME, RC=STATUS)
-            VERIFY_(STATUS)
-
-            !Identify fixed species such as O2, N2, ad.
-            if (TRIM(NAME) == 'ACET' .OR. TRIM(NAME) == 'N2'   .OR. &
-                TRIM(NAME) == 'O2'   .OR. TRIM(NAME) == 'NUMDENS')  THEN
-               conv_state%isFixedConcentration(ic) = .TRUE.
-            end if
-
-         END DO
-      END IF
-
-      ! Get the tracers from the ESMF Bundle
-      !-------------------------------------
-      ALLOCATE(concentration(conv_state%numSpecies), STAT=STATUS)
-      VERIFY_(STATUS)
-
-      DO ic = 1, conv_state%numSpecies
-         ! Get field and name from tracer bundle
-         !--------------------------------------
-         call ESMF_FieldBundleGet(ConvTR, ic, FIELD, RC=STATUS)
-         VERIFY_(STATUS)
-
-         call ESMF_FieldGet(FIELD, name=NAME, RC=STATUS)
-         VERIFY_(STATUS)
-
-         ! Get pointer to the quantity
-         !----------------------------
-         call ESMFL_BundleGetPointerToData(ConvTR, NAME, S, RC=STATUS)
-         VERIFY_(STATUS)
-
-         ! The quantity must exist; others are optional.
-         !----------------------------------------------
-         ASSERT_(associated(S ))
-
-         ALLOCATE(concentration(ic)%pArray3d(i1:i2,j1:j2,km), STAT=STATUS)
-         VERIFY_(STATUS)
-
-         concentration(ic)%pArray3d(:,:,km:1:-1) = S(:,:,:)
-      END DO
-
-      ! Satisfy the imports
-      !--------------------
-      CALL MAPL_GetPointer(impConv,          T,        'T', __RC__)
-      CALL MAPL_GetPointer(impConv,        zpbl,    'ZPBL', __RC__)
-      CALL MAPL_GetPointer(impConv,         ple,     'PLE', __RC__)
-      CALL MAPL_GetPointer(impConv,   totalMass,    'MASS', __RC__)
-      CALL MAPL_GetPointer(impConv,         zle,     'ZLE', __RC__)
-      CALL MAPL_GetPointer(impConv,     CNV_MFD, 'CNV_MFD', __RC__)
-      CALL MAPL_GetPointer(impConv,     CNV_MFC, 'CNV_MFC', __RC__)
-
-      allocate(pbl(i1:i2,j1:j2),                 STAT=STATUS); VERIFY_(STATUS)
-      allocate(press3c(i1:i2,j1:j2,k1:k2),       STAT=STATUS); VERIFY_(STATUS)
-      allocate(press3e(i1:i2,j1:j2,k1-1:k2),     STAT=STATUS); VERIFY_(STATUS)
-      ALLOCATE(pl(i1:i2,j1:j2,k1:k2),            STAT=STATUS); VERIFY_(STATUS)
-      ALLOCATE(mass(i1:i2,j1:j2,k1:k2),          STAT=STATUS); VERIFY_(STATUS)
-      allocate(gridBoxHeight(i1:i2,j1:j2,k1:k2), STAT=STATUS); VERIFY_(STATUS)
-      ALLOCATE(cmf(i1:i2,j1:j2,k1:k2),           STAT=STATUS); VERIFY_(STATUS)
-      ALLOCATE(dtrain(i1:i2,j1:j2,k1:k2),        STAT=STATUS); VERIFY_(STATUS)
-      ALLOCATE(eu(i1:i2,j1:j2,k1:k2),            STAT=STATUS); VERIFY_(STATUS)
-      ALLOCATE(ed(i1:i2,j1:j2,k1:k2),            STAT=STATUS); VERIFY_(STATUS)
-      ALLOCATE(md(i1:i2,j1:j2,k1:k2),            STAT=STATUS); VERIFY_(STATUS)
-      ALLOCATE(kel(i1:i2,j1:j2,k1:k2),           STAT=STATUS); VERIFY_(STATUS)
-
-      pbl     (:,:)       = zpbl(:,:)
-      kel     (:,:,k1:k2) = T        (:,:,km:1:-1)
-      cmf     (:,:,k1:k2) = CNV_MFC  (:,:,km-1:0:-1)
-      dtrain  (:,:,k1:k2) = CNV_MFD  (:,:,km:1:-1)
-      mass    (:,:,k1:k2) = totalMass(:,:,km:1:-1)
-      pl      (:,:,k1:k2) = (ple(:,:,0:km-1)+ple(:,:,1:km))*0.50
-
-      press3c(i1:i2,j1:j2,:)       = pl (:,:,km:1:-1)*Pa2hPa
-      press3e(i1:i2,j1:j2,k1-1:k2) = ple(:,:,km:0:-1)*Pa2hPa
-
-      ! This formulation was suggested by Steve Steentod (25Nov2014)
-      DO ik=1,km
-         kR = km-ik+1
-         eu(:,:,kR) = CNV_MFC(:,:,ik-1) - CNV_MFC(:,:,ik) + dtrain(:,:,kR)
-      END DO
-
-      ed = 0.0
-      md = 0.0
-
-      DO ik=1,km
-         kR = km-ik+1
-         gridBoxHeight(:,:,kR) = zle(:,:,ik-1)-zle(:,:,ik)         ! m
-      END DO
-
-      tdt = cdt
-
-      call doConvectiveTransport (conv_state%det_ent, conv_state%do_downdraft, pbl, cmf, &
-                      dtrain, eu, ed, md, gridBoxHeight, mass, kel, press3e,       &
-                      concentration, conv_state%isFixedConcentration, conv_state%cellArea, tdt,  &
-                      i1, i2, j1, j2, k1, k2, ilong, ivert, conv_state%numSpecies)
-
-      deallocate(pbl )
-      deallocate(dtrain, cmf, kel, eu, ed, md)
-      deallocate(press3e, press3c, mass, gridBoxHeight, pl)
-
-      ! Pass back the tracers to the ESMF Bundle
-      !------------------------------------------
-      DO ic = 1, conv_state%numSpecies
-         call ESMF_FieldBundleGet(ConvTR, ic, FIELD, RC=STATUS)
-         VERIFY_(STATUS)
-
-         call ESMF_FieldGet(FIELD, name=NAME, RC=STATUS)
-         VERIFY_(STATUS)
-
-         call ESMFL_BundleGetPointerToData(ConvTR, NAME, S, RC=STATUS)
-         VERIFY_(STATUS)
-
-         ! Do not forget to re-order the vertical levels
-         S(:,:,:) = concentration(ic)%pArray3d(:,:,km:1:-1)
-      END DO
-
-      CALL CleanArrayPointer(concentration, STATUS)
-      VERIFY_(STATUS)
+      end if
 
    RETURN_(ESMF_SUCCESS)
 
@@ -651,22 +500,22 @@ CONTAINS
 ! !INTERFACE:
 !
 
-   SUBROUTINE Finalize_ ( gc, impConv, expConv, clock, rc )
+      SUBROUTINE Finalize_ ( gc, impConv, expConv, clock, rc )
 
 ! !USES:
 
-  implicit NONE
+      implicit NONE
 
 ! !INPUT PARAMETERS:
 
-   type(ESMF_Clock),  intent(inout) :: clock      ! The clock
+      type(ESMF_Clock),  intent(inout) :: clock      ! The clock
 
 ! !OUTPUT PARAMETERS:
 
-   type(ESMF_GridComp), intent(inout)  :: gc      ! Grid Component
-   type(ESMF_State), intent(inout) :: impConv     ! Import State
-   type(ESMF_State), intent(inout) :: expConv     ! Export State
-   integer, intent(out) ::  rc                    ! Error return code:
+      type(ESMF_GridComp), intent(inout)  :: gc      ! Grid Component
+      type(ESMF_State), intent(inout) :: impConv     ! Import State
+      type(ESMF_State), intent(inout) :: expConv     ! Export State
+      integer, intent(out) ::  rc                    ! Error return code:
                                                   !  0 - all is well
                                                   !  1 - 
 
@@ -679,41 +528,78 @@ CONTAINS
 !BOC
 !  ErrLog Variables
 !  ----------------
-   character(len=ESMF_MAXSTR)      :: IAm = 'Finalize_'
-   integer                         :: STATUS
-   character(len=ESMF_MAXSTR)      :: COMP_NAME
+      character(len=ESMF_MAXSTR)      :: IAm = 'Finalize_'
+      integer                         :: STATUS
+      character(len=ESMF_MAXSTR)      :: COMP_NAME
 
-   integer                         :: nymd, nhms  ! time
-   real                            :: cdt         ! chemistry timestep (secs)
+      type(gmiConvection_GridComp), pointer     :: gmiCONV      ! Grid Component
+      type(genConvection_GridComp), pointer     :: genCONV      ! Grid Component
+      integer                         :: nymd, nhms  ! time
+      real                            :: cdt         ! chemistry timestep (secs)
+
+      type(T_Convection_state), pointer   :: state
+      type (T_Convection_wrap)            :: WRAP
 
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
-   call ESMF_GridCompGet( GC, NAME=COMP_NAME, RC=STATUS )
-   VERIFY_(STATUS)
-   Iam = TRIM(COMP_NAME)//"Finalize"
+      call ESMF_GridCompGet( GC, NAME=COMP_NAME, RC=STATUS )
+      VERIFY_(STATUS)
+      Iam = TRIM(COMP_NAME)//"Finalize"
+
+
+      ! Get my private state from the component
+      !----------------------------------------
+      call ESMF_UserCompGetInternalState(gc, 'Convection_state', WRAP, STATUS)
+      VERIFY_(STATUS)
+
+      state => WRAP%PTR
 
 !  Get ESMF parameters from gc and clock
 !  -------------------------------------
-   call extract_ ( gc, clock,  nymd, nhms, cdt, STATUS )
-   VERIFY_(STATUS)
+      call extract_ ( gc, clock, genCONV, gmiCONV, nymd, nhms, cdt, STATUS, &
+                      state = state )
+      VERIFY_(STATUS)
+
+!  Call ESMF version
+!  -----------------
+      if (state%convecType == 1) then
+         call finalizeGenericConvection ( genCONV )
+      elseif (state%convecType == 2) then
+         call finalizeGmiConvection ( gmiCONV )
+      end if
 
 !  Finalize MAPL Generic.  Atanas says, "Do not deallocate foreign objects."
 !  -------------------------------------------------------------------------
-   call MAPL_GenericFinalize ( gc, impConv, expConv, clock,  RC=STATUS )
-   VERIFY_(STATUS)
+      call MAPL_GenericFinalize ( gc, impConv, expConv, clock,  RC=STATUS )
+      VERIFY_(STATUS)
+
+!  Destroy Legacy state
+!  --------------------
+      if (state%convecType == 1) then
+         deallocate ( state%genCONV, stat = STATUS )
+         VERIFY_(STATUS)
+      elseif (state%convecType == 2) then
+         deallocate ( state%gmiCONV, stat = STATUS )
+         VERIFY_(STATUS)
+      end if
 
    RETURN_(ESMF_SUCCESS)
 
    END SUBROUTINE Finalize_
 !EOC
 !-------------------------------------------------------------------------
-    SUBROUTINE extract_ ( gc, clock, nymd, nhms, cdt, rc )
+    SUBROUTINE extract_ ( gc, clock, genCONV, gmiCONV, nymd, nhms, cdt, &
+                          rc, state )
 
     type(ESMF_GridComp), intent(inout) :: gc
     type(ESMF_Clock), intent(in)       :: clock
+    type(gmiConvection_GridComp), pointer :: gmiCONV
+    type(genConvection_GridComp), pointer :: genCONV
     integer, intent(out)               :: nymd, nhms
     real, intent(out)                  :: cdt
     integer, intent(out)               :: rc
+    type(T_Convection_state), pointer, optional   :: state
+
 
     type(T_Convection_state), pointer    :: myState
 
@@ -725,6 +611,7 @@ CONTAINS
 
     type(ESMF_Time)      :: TIME
     type(ESMF_Config)    :: CF
+    type(T_Convection_Wrap)  :: wrap
     integer              :: IYR, IMM, IDD, IHR, IMN, ISC
 
 
@@ -733,6 +620,35 @@ CONTAINS
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, RC=STATUS )
     VERIFY_(STATUS)
     Iam = trim(COMP_NAME) // 'extract_'
+
+    rc = 0
+
+!   Get my internal state
+!   ---------------------
+    call ESMF_UserCompGetInternalState(gc, 'Convection_state', WRAP, STATUS)
+    VERIFY_(STATUS)
+    myState => wrap%ptr
+    if ( present(state) ) then
+         state => wrap%ptr
+    end if
+
+!   This is likely to be allocated during initialize only
+!   -----------------------------------------------------
+      if (myState%convecType == 1) then
+         if ( .not. associated(myState%genCONV) ) then
+              allocate ( myState%genCONV, stat=STATUS )
+              VERIFY_(STATUS)
+         end if
+
+         genCONV  => myState%genCONV
+      elseif (myState%convecType == 2) then
+         if ( .not. associated(myState%gmiCONV) ) then
+              allocate ( myState%gmiCONV, stat=STATUS )
+              VERIFY_(STATUS)
+         end if
+
+         gmiCONV  => myState%gmiCONV
+      end if
 
 !   Get the configuration
 !   ---------------------
@@ -743,6 +659,11 @@ CONTAINS
 !   -------------
     call ESMF_ConfigGetAttribute ( CF, cdt, LABEL="RUN_DT:", RC=STATUS )
     VERIFY_(STATUS)
+
+!   Disable Option for Modified cdt (Chemistry does not operate with modified refresh intervals)
+!   --------------------------------------------------------------------------------------------
+!   call ESMF_ConfigGetAttribute ( CF, cdt, LABEL="CHEMISTRY_DT:", DEFAULT=cdt, RC=STATUS )
+!   VERIFY_(STATUS)
 
 !   Extract nymd, nhms, day of year from clock
 !   ------------------------------------------

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CTM_rasCalculationsMod.F90
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/CTM_rasCalculationsMod.F90
@@ -11,7 +11,7 @@
 ! !USES:
 !
       use ESMF
-      use MAPL
+      use MAPL_Mod
       use GEOS_Mod
       use GEOS_UtilsMod
 

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/GenericConvectionMethod_mod.F90
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/GenericConvectionMethod_mod.F90
@@ -178,7 +178,7 @@
 ! !INTERFACE:
 !
       subroutine runGenericConvection (self, impConv, expConv, nymd, nhms,  &
-                   tdt, enable_rasCalculations, rc)
+                   tdt, rc)
 !
 ! !USES:
 !
@@ -186,7 +186,6 @@
       TYPE(ESMF_State), INTENT(INOUT) :: impConv ! Import State
       INTEGER, INTENT(IN) :: nymd, nhms          ! time
       REAL,    INTENT(IN) :: tdt                 ! chemical timestep (secs)
-      LOGICAL, INTENT(IN) :: enable_rasCalculations ! do RAS calculations?
 !
 ! !OUTPUT PARAMETERS:
       INTEGER, INTENT(OUT) ::  rc                ! Error return code:
@@ -341,13 +340,8 @@
       CALL MAPL_GetPointer(impConv,       ple,     'PLE', RC=STATUS); VERIFY_(STATUS)
       CALL MAPL_GetPointer(impConv, totalMass,    'MASS', RC=STATUS); VERIFY_(STATUS)
       CALL MAPL_GetPointer(impConv,       zle,     'ZLE', RC=STATUS); VERIFY_(STATUS)
-      IF (enable_rasCalculations) THEN
-         CALL MAPL_GetPointer(expConv,   CNV_MFD, 'CNV_MFD', RC=STATUS); VERIFY_(STATUS)
-         CALL MAPL_GetPointer(expConv,   CNV_MFC, 'CNV_MFC', RC=STATUS); VERIFY_(STATUS)
-      ELSE
-         CALL MAPL_GetPointer(impConv,   CNV_MFD, 'CNV_MFD', RC=STATUS); VERIFY_(STATUS)
-         CALL MAPL_GetPointer(impConv,   CNV_MFC, 'CNV_MFC', RC=STATUS); VERIFY_(STATUS)
-      ENDIF
+      CALL MAPL_GetPointer(impConv,   CNV_MFD, 'CNV_MFD', RC=STATUS); VERIFY_(STATUS)
+      CALL MAPL_GetPointer(impConv,   CNV_MFC, 'CNV_MFC', RC=STATUS); VERIFY_(STATUS)
 
       allocate(pbl(i1:i2,j1:j2),                 STAT=STATUS); VERIFY_(STATUS)
       allocate(press3c(i1:i2,j1:j2,k1:k2),  STAT=STATUS); VERIFY_(STATUS)

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/GmiConvectionMethod_mod.F90
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/GmiConvectionMethod_mod.F90
@@ -13,10 +13,11 @@
 !
 ! !USES:
       use ESMF
-      use MAPL
+      use MAPL_Mod
       USE Chem_UtilMod
       use GmiArrayBundlePointer_mod
       USE GmiESMFrcFileReading_mod
+      USE convectiveTransport_mod
 !
       implicit none
 !
@@ -164,39 +165,31 @@
       !------ ------------------------
 
       call ESMF_ConfigGetAttribute(convConfigFile, self%convec_opt, &
-     &                label   = "convec_opt:",&
-     &                default = 0, rc=STATUS )
-      VERIFY_(STATUS)
+                      label   = "convec_opt:",&
+                      default = 0, __RC__ )
 
-      call ESMF_ConfigGetAttribute(convConfigFile, value=self%det_ent, &
-                     label="det_ent:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(convConfigFile, self%det_ent, &
+                     label = "det_ent:", default=.false., __RC__ )
 
-      call ESMF_ConfigGetAttribute(convConfigFile, value=self%do_downdraft, &
-                     label="do_downdraft:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(convConfigFile, self%do_downdraft, &
+                     label = "do_downdraft:", default=.false., __RC__  )
 
-      call ESMF_ConfigGetAttribute(convConfigFile, value=self%do_old_ncar, &
-                     label="do_old_ncar:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(convConfigFile, self%do_old_ncar, &
+                     label = "do_old_ncar:", default=.false., __RC__ )
 
       call ESMF_ConfigGetAttribute(convConfigFile, self%met_opt, &
-     &                label   = "met_opt:",&
-     &                default = 0, rc=STATUS )
-      VERIFY_(STATUS)
+                      label   = "met_opt:",&
+                      default = 0, __RC__ )
 
       call ESMF_ConfigGetAttribute(convConfigFile, self%chem_opt, &
-     &                label   = "chem_opt:",&
-     &                default = 0, rc=STATUS )
-      VERIFY_(STATUS)
+                      label   = "chem_opt:",&
+                      default = 0, __RC__ )
 
-      call ESMF_ConfigGetAttribute(convConfigFile, value=self%do_wetdep, &
-                     label="do_wetdep:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(convConfigFile, self%do_wetdep, &
+                     label = "do_wetdep:", default=.false., __RC__ )
 
-      call ESMF_ConfigGetAttribute(convConfigFile, value=self%do_drydep, &
-                     label="do_drydep:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(convConfigFile, self%do_drydep, &
+                     label = "do_drydep:", default=.false., __RC__ )
 
       IF ( MAPL_AM_I_ROOT() ) THEN
          PRINT*," -----> det_ent      = ", self%det_ent
@@ -241,7 +234,7 @@
 ! !INTERFACE:
 !
       subroutine runGmiConvection (self, impConv, expConv, nymd, nhms,  &
-                    tdt, enable_rasCalculations, rc)
+                    tdt, rc)
 !
 ! !USES:
 !
@@ -249,7 +242,6 @@
       TYPE(ESMF_State), INTENT(INOUT) :: impConv ! Import State
       INTEGER, INTENT(IN) :: nymd, nhms          ! time
       REAL,    INTENT(IN) :: tdt                 ! chemical timestep (secs)
-      LOGICAL, INTENT(IN) :: enable_rasCalculations ! do RAS calculations?
 !
 ! !OUTPUT PARAMETERS:
       INTEGER, INTENT(OUT) ::  rc                ! Error return code:
@@ -449,14 +441,8 @@
       CALL MAPL_GetPointer(impConv,       ple,     'PLE', RC=STATUS); VERIFY_(STATUS)
       CALL MAPL_GetPointer(impConv, totalMass,    'MASS', RC=STATUS); VERIFY_(STATUS)
       CALL MAPL_GetPointer(impConv,       zle,     'ZLE', RC=STATUS); VERIFY_(STATUS)
-
-      IF (enable_rasCalculations) THEN
-         CALL MAPL_GetPointer(expConv,   CNV_MFD, 'CNV_MFD', RC=STATUS); VERIFY_(STATUS)
-         CALL MAPL_GetPointer(expConv,   CNV_MFC, 'CNV_MFC', RC=STATUS); VERIFY_(STATUS)
-      ELSE
-         CALL MAPL_GetPointer(impConv,   CNV_MFD, 'CNV_MFD', RC=STATUS); VERIFY_(STATUS)
-         CALL MAPL_GetPointer(impConv,   CNV_MFC, 'CNV_MFC', RC=STATUS); VERIFY_(STATUS)
-      ENDIF
+      CALL MAPL_GetPointer(impConv,   CNV_MFD, 'CNV_MFD', RC=STATUS); VERIFY_(STATUS)
+      CALL MAPL_GetPointer(impConv,   CNV_MFC, 'CNV_MFC', RC=STATUS); VERIFY_(STATUS)
 
       allocate(lwi_flags(i1:i2,j1:j2),           STAT=STATUS); VERIFY_(STATUS)
       allocate(pbl(i1:i2,j1:j2),                 STAT=STATUS); VERIFY_(STATUS)

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/convectiveTransport_mod.F90
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/convectiveTransport_mod.F90
@@ -9,10 +9,12 @@
 !
 module convectiveTransport_mod
 
+      USE GmiArrayBundlePointer_mod
+
       implicit none
 
       private 
-      public  :: convectiveTransport
+      public  :: doConvectiveTransport
 !
 ! !DESCRIPTION:
 ! Module for the convective transport.
@@ -20,6 +22,176 @@ module convectiveTransport_mod
 !EOP
 !-----------------------------------------------------------------------------
 CONTAINS
+!-------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: doConvectiveTransport
+!
+! !INTERFACE:
+!
+      subroutine doConvectiveTransport (det_ent, do_downdraft, pbl, cldmas, &
+                      dtrn, eu, ed, md, grid_height, mass, kel, press3e,       &
+                      concentration, isFixedConcentration, mcor, tdt,          &
+                      i1, i2, j1, j2, k1, k2, ilong, ivert, num_species)
+!
+! !INPUT PARAMETER:
+      integer, intent(in) :: i1, i2, j1, j2, k1, k2
+      integer, intent(in) :: ilong, ivert, num_species
+      logical, intent(in) :: isFixedConcentration(:)
+      logical, intent(in) :: det_ent ! flag for doing detrainment then entrainment
+      logical, intent(in) :: do_downdraft ! flag for doing downdrafts
+      real*8 , intent(in) :: tdt          ! model time step  (s)
+      real*8 , intent(in) :: mcor       (i1:i2, j1:j2) ! area of each grid box (m^2)
+      real*8 , intent(in) :: pbl        (i1:i2,j1:j2) ! planetary boundary layer thickness (m)
+      real*8 , intent(in) :: cldmas     (i1:i2,j1:j2,k1:k2) ! convective mass flux in     updraft (kg/m^2/s)
+      real*8 , intent(in) :: dtrn       (i1:i2,j1:j2,k1:k2) ! detrainment rate (DAO:kg/m^2*s, NCAR:s^-1)
+      real*8 , intent(in) :: eu         (i1:i2,j1:j2,k1:k2) ! ntrainment into convective updraft (s^-1)
+      real*8 , intent(in) :: ed         (i1:i2,j1:j2,k1:k2) ! entrainment into convective downdraft (s^-1)
+      real*8 , intent(in) :: md         (i1:i2,j1:j2,k1:k2) ! convective mass flux in downdraft (kg/m^2/s)
+      real*8 , intent(in) :: grid_height(i1:i2,j1:j2,k1:k2) ! grid box height  (m)
+      real*8 , intent(in) :: mass       (i1:i2,j1:j2,k1:k2) ! mass of air in each grid box (kg)
+      real*8 , intent(in) :: kel        (i1:i2,j1:j2,k1:k2) ! temperature      (degK)
+      real*8 , intent(in) :: press3e    (i1:i2,j1:j2,k1-1:k2) ! atmospheric pressure at the edge of each grid box (mb)
+!
+! !INPUT/OUTPUT PARAMETERS:
+                             ! species concentration, known at zone centers (mixing ratio)
+      type (t_GmiArrayBundle), intent(inOut) :: concentration(num_species)
+!
+! !DEFINED PARAMETERS:
+      real*8, parameter :: MBSTH = 1.0d-15 ! threshold below which we treat 
+                                           ! mass fluxes as zero (mb/s)
+      real*8, parameter :: GMI_G  =   9.81d0 ! mean surface gravity accel. (m/s^2)
+      real*8, parameter :: PASPMB = 100.00d0 ! pascals  per millibar
+!
+! !DESCRIPTION:
+! This is the interface routine to Convective Transport.  
+! It formats the gem variables to satisfy the Convective Transport routine.
+!
+!EOP
+!------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+      character (len=75) :: err_msg
+      integer :: iku
+      integer :: il, ij, ik, ic
+      integer :: il2g                      ! gathered index to operate over
+      integer :: itdt_conv
+      integer :: num_conv_steps
+      real*8  :: rnum_conv_steps
+      real*8  :: tdt_conv
+      real*8  :: xmbsth
+      integer :: ideep(ilong)              ! gathering array
+      integer :: pbli (ilong)              ! index of pbl height
+      real*8  :: updraft_velocity(i1:i2)   ! velocity in convective updraft
+                                           ! (m/s)
+      real*8  :: dpi(ilong,  k1:k2)        ! delta pressure between interfaces
+      real*8  :: dui(ilong,  k1:k2)        ! mass detraining from updraft
+      real*8  :: eui(ilong,  k1:k2)        ! mass entraining into updraft
+      real*8  :: mui(ilong,  k1:k2)        ! mass flux up
+      real*8  :: mdi(ilong,  k1:k2)        ! mass flux down
+      real*8  :: fracis(i1:i2, k1:k2, num_species)  ! insoluble fraction of tracer
+      real*8  :: qq    (i1:i2, k1:k2, num_species)  ! tracer array including moisture
+
+      ideep(:) = 0
+      pbli (:) = 0
+
+      dpi(:,:) = 0.0d0
+      dui(:,:) = 0.0d0
+      eui(:,:) = 0.0d0
+      mui(:,:) = 0.0d0
+      mdi(:,:) = 0.0d0
+
+      fracis(:,:,:) = 0.0d0
+
+      xmbsth = MBSTH
+
+      updraft_velocity(:) = 0.0d0
+
+      ! -----------------------------------------------------------
+      ! Calculate any needed sub-cycling of the convection operator
+      ! by comparing the mass flux over the full time step to the
+      ! mass within the grid box.
+      ! -----------------------------------------------------------
+
+      num_conv_steps = Maxval (tdt * cldmas(:,:,:) * Spread (mcor(:,:), 3, k2-k1+1) /  &
+                               mass(:,:,:)) + 1.0d0
+
+      rnum_conv_steps = num_conv_steps
+      tdt_conv        = tdt / rnum_conv_steps
+
+      IJLOOP: do ij = j1, j2
+         il2g = 0
+
+         ILLOOP: do il = i1, i2
+            ! ----------------------------------------------------
+            ! Verify that there is convection in the current cell.
+            ! ----------------------------------------------------
+            if (Maxval (cldmas(il,ij,:)) >= 0.0d0) then
+               il2g = il2g + 1
+               ideep(il2g) = il
+
+               dpi(il2g,:) = (press3e(il,ij,k2-1:k1-1:-1) -  &
+                              press3e(il,ij,k2:k1:-1)) * PASPMB
+
+               mui(il2g,:) = cldmas(il,ij,k2:k1:-1) * GMI_G
+
+               eui(il2g,k1+1:k2-1) = Max (0.0d0, cldmas(il,ij,k2-1:k1+1:-1) -  &
+                                                 cldmas(il,ij,k2-2:k1  :-1) +  &
+                                                 dtrn  (il,ij,k2-1:k1+1:-1))
+
+               eui(il2g,:) = eui(il2g,:) * GMI_G
+
+               if (det_ent) dui(il2g,:) = dtrn(il,ij,k2:k1:-1) * GMI_G
+            end if
+         end do ILLOOP
+
+         IL2GIF: if (il2g /= 0) then
+            fracis(:,:,:) = 1.0d0
+
+            ! ----------------------------------------------------------------
+            ! Find the index of the top of the planetary boundary layer (pbl).
+            ! Convection will assume well mixed tracers below that level.
+            ! ----------------------------------------------------------------
+            do il = 1, il2g
+               pbli(il) = 0
+
+               IKLOOP: do ik = k1, k2
+                  if (pbl(ideep(il),ij) < Sum (grid_height(ideep(il),ij,k1:ik))) then
+                     pbli(il) = ik
+                     exit IKLOOP
+                  end if
+               end do IKLOOP
+
+               if (pbli(il) == 0) then
+                  err_msg = 'Could not find pbl in doConvectiveTransport.'
+                  PRINT*, err_msg
+                  stop
+               end if
+
+               pbli(il) = k2 - pbli(il)
+            end do
+
+            ITDTCLOOP: do itdt_conv = 1, num_conv_steps
+               do ic = 1, num_species
+                  qq(:,k2:k1:-1,ic) = concentration(ic)%pArray3D(:,ij,k1:k2)
+               end do
+
+               call convectiveTransport (il2g, tdt_conv, xmbsth, ideep,  &
+                           pbli, dui, eui, mui, mdi, dpi, fracis, qq, &
+                           isFixedConcentration, i1, i2, k1, k2, ilong, num_species)
+
+               do ic = 1, num_species
+                  concentration(ic)%pArray3D(:,ij,k1:k2) = qq(:,k2:k1:-1,ic)
+               end do
+            end do ITDTCLOOP
+         end if IL2GIF
+      end do IJLOOP
+
+      return
+
+      end subroutine doConvectiveTransport
+!EOC
 !-----------------------------------------------------------------------------
 !BOP
 !

--- a/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/convectiveTransport_mod.F90
+++ b/src/Components/GEOSctm_GridComp/CTMconvection_GridComp/convectiveTransport_mod.F90
@@ -15,6 +15,7 @@ module convectiveTransport_mod
 
       private 
       public  :: doConvectiveTransport
+      public  :: convectiveTransport
 !
 ! !DESCRIPTION:
 ! Module for the convective transport.

--- a/src/Components/GEOSctm_GridComp/GEOS_ctmHistGridComp.F90
+++ b/src/Components/GEOSctm_GridComp/GEOS_ctmHistGridComp.F90
@@ -1,0 +1,655 @@
+#include "MAPL_Generic.h"
+!-------------------------------------------------------------------------
+!         NASA/GSFC, Software Systems Support Office, Code 610.3         !
+!-------------------------------------------------------------------------
+!BOP
+!
+! !MODULE: GEOS_ctmhistGridComp -- Produces meteorological forcings for HISTORY
+!
+! !INTERFACE:
+!
+      module GEOS_ctmHistGridComp
+!
+! !USES:
+      use ESMF
+      use MAPL
+
+      implicit none
+      private
+
+! !PUBLIC MEMBER FUNCTIONS:
+
+      public SetServices
+      public compAreaWeightedAverage
+
+      interface compAreaWeightedAverage
+         module procedure compAreaWeightedAverage_2d
+         module procedure compAreaWeightedAverage_3d
+      end interface
+!
+! !DESCRIPTION:
+! This GC is used to derive variables needed by the CTM GC children.
+
+      !Derived types for the internal state
+      type T_CTMhist_STATE
+         private
+         logical                    :: output_forcingData  = .FALSE. ! Export variables to HISTORY?
+         character(len=ESMF_MAXSTR) :: metType                       ! MERRA2 or MERRA1 or FPIT or FP
+      end type T_CTMhist_STATE
+
+      type CTMhist_WRAP
+         type (T_CTMhist_STATE), pointer :: PTR
+      end type CTMhist_WRAP
+!
+! !AUTHORS:
+! Jules.Kouatchou-1@nasa.gov
+!
+!EOP
+!-------------------------------------------------------------------------
+      integer,  parameter :: r8     = SELECTED_REAL_KIND(14,300)
+      integer,  parameter :: r4     = SELECTED_REAL_KIND(6,30)
+
+      real(r8), parameter :: RADIUS = MAPL_RADIUS
+      real(r8), parameter :: PI     = MAPL_PI_R8
+      real(r8), parameter :: GPKG   = 1000.0d0
+      real(r8), parameter :: MWTAIR =   28.96d0
+      real(r8), parameter :: SecondsPerMinute = 60.0d0
+
+!-------------------------------------------------------------------------
+      CONTAINS
+!-------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: SetServices -- Sets ESMF services for this component
+!
+! !INTERFACE:
+!
+      subroutine SetServices ( GC, RC )
+!
+! !INPUT/OUTPUT PARAMETERS:
+      type(ESMF_GridComp), intent(INOUT) :: GC  ! gridded component
+!
+! !OUTPUT PARAMETERS:
+      integer, intent(OUT)               :: RC  ! return code
+!
+! !DESCRIPTION:  
+!   The SetServices for the CTM Der GC needs to register its
+!   Initialize and Run.  It uses the MAPL\_Generic construct for defining 
+!   state specs. 
+!
+!EOP
+!-------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+      integer                    :: STATUS
+      type (ESMF_Config)         :: CF
+      type (ESMF_Config)         :: configFile
+      character(len=ESMF_MAXSTR) :: COMP_NAME
+      CHARACTER(LEN=ESMF_MAXSTR) :: rcfilen = 'CTM_GridComp.rc'
+      character(len=ESMF_MAXSTR) :: IAm = 'SetServices'
+      type (T_CTMhist_STATE), pointer :: state
+      type (CTMhist_WRAP)             :: wrap
+
+     ! Get my name and set-up traceback handle
+     ! ---------------------------------------
+      call ESMF_GridCompGet( GC, NAME=COMP_NAME, CONFIG=CF, __RC__ )
+      Iam = trim(COMP_NAME) // TRIM(Iam)
+
+      ! Wrap internal state for storing in GC; rename legacyState
+      ! -------------------------------------
+      allocate ( state, stat=STATUS )
+      VERIFY_(STATUS)
+      wrap%ptr => state
+
+     ! Register services for this component
+     ! ------------------------------------
+      call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE, Initialize, __RC__ )
+      call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,  Run,        __RC__ )
+
+      ! Save pointer to the wrapped internal state in the GC
+      !-----------------------------------------------------
+
+      call ESMF_UserCompSetInternalState ( GC, 'CTMhist', wrap, STATUS )
+      VERIFY_(STATUS)
+
+      configFile = ESMF_ConfigCreate(__RC__)
+
+      call ESMF_ConfigLoadFile(configFile, TRIM(rcfilen), __RC__ )
+
+      call ESMF_ConfigGetAttribute(configFile, state%output_forcingData,     &
+                             Default  = .FALSE.,                       &
+                             Label    = "output_forcingData:",  __RC__ )
+
+      ! Type of meteological fields (MERRA2 or MERRA1 or FPIT or FP)
+      call ESMF_ConfigGetAttribute(configFile, state%metType,             &
+                                     Default  = 'MERRA2',           &
+                                     Label    = "metType:",  __RC__ )
+
+      IF ((TRIM(state%metType) == "F515_516") .OR. &
+          (TRIM(state%metType) == "F5131"))        state%metType = "FP"
+
+! !IMPORT STATE:
+      !------------------------------------------
+      ! If we want vertical remapping must add PS
+      !------------------------------------------
+      call MAPL_AddImportSpec(GC,                              &
+           SHORT_NAME        = 'PS',                           &
+           LONG_NAME         = 'surface_pressure',             &
+           UNITS             = 'Pa',                           &
+           DIMS              = MAPL_DimsHorzOnly,              &
+           VLOCATION         = MAPL_VLocationNone,    __RC__)
+
+!      call MAPL_AddImportSpec(GC,                              &
+!           SHORT_NAME        = 'AREA',                         &
+!           LONG_NAME         = 'agrid_cell_area',              &
+!           UNITS             = 'm+2',                          &
+!           DIMS              = MAPL_DimsHorzOnly,              &
+!           VLOCATION         = MAPL_VLocationNone,    __RC__)
+
+      call MAPL_AddImportSpec(GC,                              &
+           SHORT_NAME = 'PHIS',                                &
+           LONG_NAME  = 'surface_geopotential_height',         &
+           UNITS      = 'm2 s-2',                              &
+           DIMS       = MAPL_DimsHorzOnly,                     &
+           VLOCATION  = MAPL_VLocationNone,              __RC__)
+
+      call MAPL_AddImportSpec(GC,                              &
+           SHORT_NAME = 'SLP',                                 &
+           LONG_NAME  = 'sea_level_pressure',                  &
+           UNITS      = 'Pa',                                  &
+           DIMS       = MAPL_DimsHorzOnly,                     &
+           VLOCATION  = MAPL_VLocationNone,              __RC__)
+
+      call MAPL_AddImportSpec(GC,                              &
+           SHORT_NAME = 'TROPP',                               &
+           LONG_NAME  = 'tropopause_pressure_based_on_blended_estimate', &
+           UNITS      = 'Pa',                                  &
+           DIMS       = MAPL_DimsHorzOnly,                     &
+           VLOCATION  = MAPL_VLocationNone,              __RC__)
+
+      call MAPL_AddImportSpec ( gc,                            &
+           SHORT_NAME = 'QLTOT',                               &
+           LONG_NAME  = 'mass_fraction_of_cloud_liquid_water', &
+           UNITS      = 'kg kg-1',                             &
+           DIMS       = MAPL_DimsHorzVert,                     &
+           VLOCATION  = MAPL_VLocationCenter,          __RC__  )
+
+      call MAPL_AddImportSpec ( gc,                            &
+           SHORT_NAME = 'QITOT',                               &
+           LONG_NAME  = 'mass_fraction_of_cloud_ice_water',    &
+           UNITS      = 'kg kg-1',                             &
+           DIMS       = MAPL_DimsHorzVert,                     &
+           VLOCATION  = MAPL_VLocationCenter,          __RC__  )
+
+      call MAPL_AddImportSpec(GC,                             &
+          SHORT_NAME = 'TS',                                  &
+          LONG_NAME  = 'surface temperature',                 &
+          UNITS      = 'K',                                   &
+          DIMS       = MAPL_DimsHorzOnly,                     &
+          VLOCATION  = MAPL_VLocationNone,            __RC__  )
+
+      call MAPL_AddImportSpec(GC,                             &
+           SHORT_NAME = 'Q',                                  &
+           LONG_NAME  = 'specific_humidity',                  &
+           UNITS      = 'kg kg-1',                            &
+           DIMS       = MAPL_DimsHorzVert,                    &
+           VLOCATION  = MAPL_VLocationCenter,         __RC__  )
+
+      ! This comes from CTM Env but not from external data files
+      call MAPL_AddImportSpec ( gc,                                  &
+           SHORT_NAME = 'PLE',                                       &
+           LONG_NAME  = 'pressure_at_layer_edges',                   &
+           UNITS      = 'Pa',                                        &
+           DIMS       = MAPL_DimsHorzVert,                           &
+           VLOCATION  = MAPL_VLocationEdge,             __RC__  )
+
+! !EXPORT STATE:
+
+      ! Default exports
+      !----------------
+      call MAPL_AddExportSpec(GC,                              &
+           SHORT_NAME = 'PS',                                  &
+           LONG_NAME  = 'surface_pressure',                    &
+           UNITS      = 'Pa',                                  &
+           DIMS       = MAPL_DimsHorzOnly,                     &
+           VLOCATION  = MAPL_VLocationNone,              __RC__)
+
+      call MAPL_AddExportSpec(GC,                              &
+           SHORT_NAME = 'PHIS',                                &
+           LONG_NAME  = 'surface_geopotential_height',         &
+           UNITS      = 'm2 s-2',                              &
+           DIMS       = MAPL_DimsHorzOnly,                     &
+           VLOCATION  = MAPL_VLocationNone,              __RC__)
+
+      call MAPL_AddExportSpec(GC,                              &
+           SHORT_NAME = 'TROPP',                               &
+           LONG_NAME  = 'tropopause_pressure_based_on_blended_estimate', &
+           UNITS      = 'Pa',                                  &
+           DIMS       = MAPL_DimsHorzOnly,                     &
+           VLOCATION  = MAPL_VLocationNone,              __RC__)
+
+      call MAPL_AddExportSpec(GC,                              &
+           SHORT_NAME = 'SLP',                                 &
+           LONG_NAME  = 'sea_level_pressure',                  &
+           UNITS      = 'Pa',                                  &
+           DIMS       = MAPL_DimsHorzOnly,                     &
+           VLOCATION  = MAPL_VLocationNone,              __RC__)
+
+      call MAPL_AddExportSpec ( gc,                            &
+           SHORT_NAME = 'QLTOT',                               &
+           LONG_NAME  = 'mass_fraction_of_cloud_liquid_water', &
+           UNITS      = 'kg kg-1',                             &
+           DIMS       = MAPL_DimsHorzVert,                     &
+           VLOCATION  = MAPL_VLocationCenter,          __RC__  )
+
+      call MAPL_AddExportSpec ( gc,                            &
+           SHORT_NAME = 'QITOT',                               &
+           LONG_NAME  = 'mass_fraction_of_cloud_ice_water',    &
+           UNITS      = 'kg kg-1',                             &
+           DIMS       = MAPL_DimsHorzVert,                     &
+           VLOCATION  = MAPL_VLocationCenter,          __RC__  )
+
+      call MAPL_AddExportSpec(GC,                              &
+           SHORT_NAME = 'TS',                                  &     
+           LONG_NAME  = 'surface temperature',                 &     
+           UNITS      = 'K',                                   &     
+           DIMS       = MAPL_DimsHorzOnly,                     &     
+           VLOCATION  = MAPL_VLocationNone,            __RC__  )
+
+      call MAPL_AddExportSpec(GC,                             &
+           SHORT_NAME = 'Q',                                  &      
+           LONG_NAME  = 'specific_humidity',                  &      
+           UNITS      = 'kg kg-1',                            &      
+           DIMS       = MAPL_DimsHorzVert,                    &      
+           VLOCATION  = MAPL_VLocationCenter,         __RC__  )
+
+      call MAPL_AddExportSpec ( gc,                           &
+           SHORT_NAME = 'DELP',                               &
+           LONG_NAME  = 'pressure_thickness',                 &
+           UNITS      = 'Pa',                                 &
+           DIMS       = MAPL_DimsHorzVert,                    &
+           VLOCATION  = MAPL_VLocationCenter,          __RC__ )
+
+      ! Set the Profiling timers
+      !-------------------------
+      call MAPL_TimerAdd(GC,    name="INITIALIZE"  , __RC__ )
+      call MAPL_TimerAdd(GC,    name="RUN"         , __RC__ )
+
+      ! Create children's gridded components and invoke their SetServices
+      ! -----------------------------------------------------------------
+      call MAPL_GenericSetServices    ( GC,  __RC__  )
+
+      RETURN_(ESMF_SUCCESS)
+  
+      end subroutine SetServices
+!
+!EOC
+!-------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Initialize -- Initialized method for composite the CTMder
+!
+! !INTERFACE:
+!
+      subroutine Initialize ( GC, IMPORT, EXPORT, CLOCK, RC )
+!
+! !INPUT/OUTPUT PARAMETERS:
+      type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+      type(ESMF_State),    intent(inout) :: IMPORT ! Import state
+      type(ESMF_State),    intent(inout) :: EXPORT ! Export state
+      type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
+!
+! !OUTPUT VARIABLES:
+      integer, optional,   intent(  out) :: RC     ! Error code
+!
+! !DESCRIPTION: 
+!  The Initialize method of the CTM Cinderella Component.
+!
+!EOP
+!-------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+      __Iam__('Initialize')
+      character(len=ESMF_MAXSTR)    :: COMP_NAME
+      type(ESMF_Grid)               :: esmfGrid
+      type (ESMF_VM)                :: VM
+      type(MAPL_MetaComp), pointer  :: ggState      ! GEOS Generic State
+      type (ESMF_Config)            :: CF
+      type (T_CTMhist_STATE), pointer :: CTMhist_STATE
+      type (CTMhist_WRAP)             :: WRAP
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+
+      !  Get my name and set-up traceback handle
+      !  ---------------------------------------
+      call ESMF_GridCompGet( GC, NAME=COMP_NAME, CONFIG=CF, VM=VM, __RC__ )
+      Iam = TRIM(COMP_NAME)//"::Initialize"
+
+      !  Initialize GEOS Generic
+      !  ------------------------
+      call MAPL_GenericInitialize ( gc, IMPORT, EXPORT, clock,  __RC__ )
+
+      !  Get my internal MAPL_Generic state
+      !  -----------------------------------
+      call MAPL_GetObjectFromGC ( GC, ggState, __RC__)
+
+      call MAPL_TimerOn(ggSTATE,"TOTAL")
+      call MAPL_TimerOn(ggSTATE,"INITIALIZE")
+
+      ! Get my private state from the component
+      !----------------------------------------
+      call ESMF_UserCompGetInternalState(gc, 'CTMhist', WRAP, STATUS)
+      VERIFY_(STATUS)
+
+      CTMhist_STATE => WRAP%PTR
+
+      IF (MAPL_AM_I_ROOT()) THEN
+         PRINT*
+         PRINT*, '<---------------------------------------------->'
+         PRINT*, TRIM(Iam)//' output_forcingData:     ', CTMhist_STATE%output_forcingData
+         PRINT*, '<---------------------------------------------->'
+         PRINT*
+      END IF
+
+
+      call MAPL_TimerOff(ggSTATE,"INITIALIZE")
+      call MAPL_TimerOff(ggSTATE,"TOTAL")
+
+      RETURN_(ESMF_SUCCESS)
+
+      end subroutine Initialize
+!EOC
+!-------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Run -- Run method
+!
+! !INTERFACE:
+!
+      subroutine Run ( GC, IMPORT, EXPORT, CLOCK, RC )
+!
+! !INPUT/OUTPUT PARAMETERS:
+      type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+      type(ESMF_State),    intent(inout) :: IMPORT ! Import state
+      type(ESMF_State),    intent(inout) :: EXPORT ! Export state
+      type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
+!
+! !OUTPUT PARAMETERS:
+      integer, optional,   intent(  out) :: RC     ! Error code
+!
+! !DESCRIPTION: 
+! The Run method of the CTM Cinderalla Component.
+!
+!EOP
+!-------------------------------------------------------------------------
+!BOC 
+!
+! !LOCAL VARIABLES:
+      character(len=ESMF_MAXSTR)      :: IAm = "Run"
+      integer                         :: STATUS
+      character(len=ESMF_MAXSTR)      :: COMP_NAME
+      type (MAPL_MetaComp), pointer   :: ggState
+      type (ESMF_Grid)                :: esmfGrid
+      type (T_CTMhist_STATE), pointer  :: CTMhist_STATE
+      type (CTMhist_wrap)              :: WRAP
+
+      real, pointer, dimension(:,:)   ::  cellArea => null()
+
+
+      real,     pointer, dimension(:,:,:) ::      Qimp => null()
+      real,     pointer, dimension(:,:,:) ::      Qexp => null()
+      real,     pointer, dimension(:,:)   ::     PSimp => null()
+      real,     pointer, dimension(:,:)   ::     PSexp => null()
+      real,     pointer, dimension(:,:)   ::     TSimp => null()
+      real,     pointer, dimension(:,:)   ::     TSexp => null()
+      real,     pointer, dimension(:,:)   ::    SLPimp => null()
+      real,     pointer, dimension(:,:)   ::    SLPexp => null()
+      real,     pointer, dimension(:,:)   ::   PHISimp => null()
+      real,     pointer, dimension(:,:)   ::   PHISexp => null()
+      real,     pointer, dimension(:,:,:) ::   DELPexp => null()
+      real,     pointer, dimension(:,:)   ::  TROPPimp => null()
+      real,     pointer, dimension(:,:)   ::  TROPPexp => null()
+      real,     pointer, dimension(:,:,:) ::  QITOTimp => null()
+      real,     pointer, dimension(:,:,:) ::  QITOTexp => null()
+      real,     pointer, dimension(:,:,:) ::  QLTOTimp => null()
+      real,     pointer, dimension(:,:,:) ::  QLTOTexp => null()
+      real,     pointer, dimension(:,:,:) ::       PLE => null()
+
+      integer :: IM, JM, LM
+      integer :: k, is, ie, js, je, nc
+      integer :: ndt, isd, ied, jsd, jed, i, j, l
+      real(r8) :: DT
+
+      ! Get the target components name and set-up traceback handle.
+      ! -----------------------------------------------------------
+      call ESMF_GridCompGet ( GC, name=COMP_NAME, Grid=esmfGrid, RC=STATUS )
+      VERIFY_(STATUS)
+      Iam = trim(COMP_NAME) // TRIM(Iam)
+
+      ! Get my internal MAPL_Generic state
+      !-----------------------------------
+      call MAPL_GetObjectFromGC ( GC, ggState, __RC__ )
+
+      call MAPL_TimerOn(ggState,"TOTAL")
+      call MAPL_TimerOn(ggState,"RUN")
+
+      ! Get my private state from the component
+      !----------------------------------------
+      call ESMF_UserCompGetInternalState(gc, 'CTMhist', WRAP, STATUS)
+      VERIFY_(STATUS)
+
+      CTMhist_STATE => WRAP%PTR
+
+      ! Get the time-step
+      ! -----------------------
+      call MAPL_GetResource( ggState, ndt, 'RUN_DT:', default=0, __RC__ )
+      DT = ndt
+
+      call MAPL_GetPointer ( IMPORT,    PSimp,     'PS',  __RC__ )
+      call MAPL_GetPointer ( EXPORT,    PSexp,     'PS', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(PSimp).AND.ASSOCIATED(PSexp)) PSexp = PSimp
+
+      call MAPL_GetPointer ( IMPORT,    TSimp,     'TS',  __RC__ )
+      call MAPL_GetPointer ( EXPORT,    TSexp,     'TS', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(TSimp).AND.ASSOCIATED(TSexp)) TSexp = TSimp
+
+      call MAPL_GetPointer ( IMPORT,   SLPimp,    'SLP',  __RC__ )
+      call MAPL_GetPointer ( EXPORT,   SLPexp,    'SLP', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(SLPimp).AND.ASSOCIATED(SLPexp)) SLPexp = SLPimp
+
+      call MAPL_GetPointer ( IMPORT,  PHISimp,   'PHIS', __RC__ )
+      call MAPL_GetPointer ( EXPORT,  PHISexp,   'PHIS', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(PHISimp).AND.ASSOCIATED(PHISexp)) PHISexp = PHISimp
+
+      call MAPL_GetPointer ( IMPORT,  TROPPimp,   'TROPP', __RC__ )
+      call MAPL_GetPointer ( EXPORT,  TROPPexp,   'TROPP', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(TROPPimp).AND.ASSOCIATED(TROPPexp)) TROPPexp = TROPPimp
+
+      call MAPL_GetPointer ( IMPORT,  QITOTimp,  'QITOT', __RC__ )
+      call MAPL_GetPointer ( EXPORT,  QITOTexp,  'QITOT', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(QITOTimp).AND.ASSOCIATED(QITOTexp)) QITOTexp = QITOTimp
+
+      call MAPL_GetPointer ( IMPORT,  QLTOTimp,  'QLTOT', __RC__ )
+      call MAPL_GetPointer ( EXPORT,  QLTOTexp,  'QLTOT', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(QLTOTimp).AND.ASSOCIATED(QLTOTexp)) QLTOTexp = QLTOTimp
+
+      call MAPL_GetPointer ( IMPORT,     Qimp,     'Q',  __RC__ )
+      call MAPL_GetPointer ( EXPORT,     Qexp,     'Q', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(Qimp).AND.ASSOCIATED(Qexp)) Qexp = Qimp
+
+      call MAPL_GetPointer ( IMPORT,  PLE,       'PLE', __RC__ )
+      call MAPL_GetPointer ( EXPORT,  DELPexp,   'DELP', ALLOC=.TRUE., __RC__ )
+      IF (ASSOCIATED(DELPexp) .AND. ASSOCIATED(PLE)) THEN
+         call compute_DELP()
+      ENDIF
+
+      call MAPL_TimerOff(ggState,"RUN")
+      call MAPL_TimerOff(ggState,"TOTAL")
+
+      ! All Done
+      ! --------
+      RETURN_(ESMF_SUCCESS)
+
+      !----------------------
+      ! - Intenal Subroutines
+      !----------------------
+         CONTAINS
+         !
+         !-------------------------------------------------------
+         !
+         subroutine compute_PLE()
+           INTEGER  :: L
+           real(r8), allocatable             :: AK(:)
+           real(r8), allocatable             :: BK(:)
+
+           allocate(AK(LM+1),stat=rc)
+           VERIFY_(rc)
+           allocate(BK(LM+1),stat=rc)
+           VERIFY_(rc)
+
+           call ESMF_AttributeGet(esmfGrid, name="GridAK", valuelist=AK, __RC__)
+           call ESMF_AttributeGet(esmfGrid, name="GridBK", valuelist=BK, __RC__)
+
+           DO L = 1, LM+1
+              PLE(:,:,L) = AK(L) + BK(L)*PSimp(:,:)
+           END DO
+
+           deallocate(AK, BK)
+
+         end subroutine compute_PLE
+         !
+         !-------------------------------------------------------
+         !
+         subroutine compute_DELP()
+           INTEGER  :: L
+
+           DO L = 1, SIZE(PLE, 3)-1
+              DELPexp(:,:,L) = PLE(:,:,L+1) - PLE(:,:,L)
+           END DO
+
+         end subroutine compute_DELP
+
+      end subroutine Run
+!------------------------------------------------------------------------------
+!BOP
+      function compAreaWeightedAverage_2d (var2D, vm, cellArea) result(wAverage)
+!
+! !INPUT PARAMETER:
+      real            :: var2D(:,:)
+      real            :: cellArea(:,:)
+      type (ESMF_VM)  :: VM
+!
+! RETURNED VALUE:
+      real  :: wAverage
+!
+! DESCRIPTION:
+! Computes the area weighted average of a 2d variable.
+!
+!EOP
+!-----------------------------------------------------------------------
+!BOC
+      logical, save :: first = .true.
+      real(r8) , save :: sumArea
+      real(r8) :: sumWeight
+      integer :: im, jm, STATUS, RC
+      real(r8), pointer :: weightVals(:,:)
+      real(r8) :: sumWeight_loc, sumArea_loc
+      character(len=ESMF_MAXSTR) :: IAm = 'compAreaWeightedAverage_2d'
+
+      ! Determine the earth surface area
+      if (first) then
+         sumArea_loc   = SUM( cellArea  (:,:)  )
+         call MAPL_CommsAllReduceSum(vm, sendbuf= sumArea_loc, &
+                                         recvbuf= sumArea, &
+                                         cnt=1, RC=status)
+         VERIFY_(STATUS)
+
+         first = .false.
+      end if
+
+      im = size(cellArea,1)
+      jm = size(cellArea,2)
+
+      allocate(weightVals(im,jm))
+      weightVals(:,:) = cellArea(:,:)*var2D(:,:)
+
+      sumWeight_loc = SUM( weightVals(:,:) )
+
+      call MAPL_CommsAllReduceSum(vm, sendbuf= sumWeight_loc, recvbuf= sumWeight, &
+         cnt=1, RC=status)
+      VERIFY_(STATUS)
+
+      wAverage = sumWeight/sumArea
+
+      deallocate(weightVals)
+
+      return
+
+      end function compAreaWeightedAverage_2d
+!EOC
+!-----------------------------------------------------------------------
+!BOP
+      function compAreaWeightedAverage_3d (var3D, vm, cellArea) result(wAverage)
+!
+! !INPUT PARAMETER:
+      real            :: var3D(:,:,:)
+      real            :: cellArea(:,:)
+      type (ESMF_VM)  :: VM
+!
+! RETURNED VALUE:
+      real  :: wAverage
+!
+! DESCRIPTION:
+! Computes the area weighted average of a 3d variable.
+!
+!EOP
+!-----------------------------------------------------------------------
+!BOC
+      logical, save :: first = .true.
+      real(r8) , save :: sumArea
+      real(r8) :: sumWeight
+      integer :: ik, im, jm, STATUS, RC
+      real(r8), pointer :: weightVals(:,:)
+      real(r8) :: sumWeight_loc, sumArea_loc
+      character(len=ESMF_MAXSTR) :: IAm = 'compAreaWeightedAverage_3d'
+
+      ! Determine the earth surface area
+      if (first) then
+         sumArea_loc   = SUM( cellArea  (:,:)  )
+         call MAPL_CommsAllReduceSum(vm, sendbuf= sumArea_loc, &
+                                         recvbuf= sumArea, &
+                                         cnt=1, RC=status)
+         VERIFY_(STATUS)
+
+         first = .false.
+      end if
+
+      im = size(cellArea,1)
+      jm = size(cellArea,2)
+
+      allocate(weightVals(im,jm))
+      weightVals(:,:) = 0.0d0
+      DO ik = lbound(var3D,3), ubound(var3D,3)
+         weightVals(:,:) = weightVals(:,:) + cellArea(:,:)*var3D(:,:,ik)
+      END DO
+
+      sumWeight_loc = SUM( weightVals(:,:) )
+
+      call MAPL_CommsAllReduceSum(vm, sendbuf= sumWeight_loc, recvbuf= sumWeight, &
+         cnt=1, RC=status)
+      VERIFY_(STATUS)
+
+      wAverage = sumWeight/sumArea
+
+      deallocate(weightVals)
+
+      return
+
+      end function compAreaWeightedAverage_3d
+!EOC
+!-----------------------------------------------------------------------
+      end module GEOS_ctmHistGridComp


### PR DESCRIPTION
This version of the code restore the Convection option (convecType=2) specific to GMI configuration. The  Convection component was refactored to only do Convective Transport regardless of the model configuration. It turns out that for GMI, a special treatment is needed.