### PR TITLE
Extend the transition date for the last batch of MERRA2 met-fields

### DIFF
--- a/src/Applications/GEOSctm_App/ctm_run.j
+++ b/src/Applications/GEOSctm_App/ctm_run.j
@@ -600,7 +600,7 @@ if( ${DRIVING_DATASETS} == MERRA2) then
         set sYear  = 2010
         set sMonth = jan10
         set MERRA2type = MERRA2_400
-        set data_Transition_Date = 20200101
+        set data_Transition_Date = 20500101
     endif
 
     set newstring = "EXTDATA_CF: ${COMPNAME}_ExtData_${sYear}.rc"


### PR DESCRIPTION
With this change, CTM can now run with MERRA2 met fields for 2020 and beyond.  Zero diff for earlier dates.