### PR TITLE
Check EGRESS to avoid infinite loop

### DIFF
--- a/src/Applications/GEOSctm_App/ctm_run.j
+++ b/src/Applications/GEOSctm_App/ctm_run.j
@@ -1017,7 +1017,11 @@ $RUN_CMD $NPES ./GEOSctm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'l
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 
-set rc =  $status
+if( -e EGRESS ) then
+   set rc = 0
+else
+   set rc = -1
+endif
 
 echo GEOSctm Run Status: $rc
 


### PR DESCRIPTION
If the model run fails, we don't want the run script to re-submit itself to SLURM in an infinite loop.
This PR fixes that bug.  It does not affect the output from a proper run of the model, so this PR is "zero diff".