### PR TITLE
Fixed clone bug in ctm_setup

### DIFF
--- a/src/Applications/GEOSctm_App/ctm_post.j
+++ b/src/Applications/GEOSctm_App/ctm_post.j
@@ -50,7 +50,9 @@ endif
 #                      Perform Post Processing
 #######################################################################
 
-setenv POST_SCRIPT @EXPDIR/post/ctmpost.script.$SLURM_JOB_ID
+setenv  EXPDIR  @EXPDIR
+
+setenv POST_SCRIPT $EXPDIR/post/ctmpost.script.$SLURM_JOB_ID
 
 /bin/cp  $GEOSUTIL/post/gcmpost.script $POST_SCRIPT
 
@@ -63,6 +65,6 @@ sed -i -e "s/AGCM_JM/GEOSctm_JM/g"        $POST_SCRIPT
 sed -i -e "s/GEOSgcm.x/GEOSctm.x/g"       $POST_SCRIPT
 sed -i -e "s/gcm_archive/ctm_archive/g"   $POST_SCRIPT
 
-$POST_SCRIPT -source @EXPDIR -ncpus $NCPUS -collections @COLLECTION -rec_plt @YYYYMM
+$POST_SCRIPT -source $EXPDIR -ncpus $NCPUS -collections @COLLECTION -rec_plt @YYYYMM
 
 exit

--- a/src/Applications/GEOSctm_App/ctm_setup
+++ b/src/Applications/GEOSctm_App/ctm_setup
@@ -2829,6 +2829,11 @@ foreach file (`cat $NEWEXPFILES`)
    sed -i -f $SEDFILE $file
 end
 
+# -------------------------------------------------------
+# To account for the old non-standard format of one file:
+# -------------------------------------------------------
+sed -i -e "s#$OLDEXPDIR#$NEWEXPDIR#"   $NEWEXPDIR/post/ctm_post.j
+
 # ------------------------------------------
 # Change the EXPDSC in HISTORY.rc to reflect
 # the fact this experiment was cloned


### PR DESCRIPTION
The standard cloning process was not properly editing ctm_post.j
and therefore the old EXPDIR string was not being changed to the new EXPDIR string.
This was due to the non-standard form of that file.

Two fixes are now included:  ctm_post.j  has a new format which will now work with the standard cloning process,
and that process (in ctm_setup) has been modified to account for ctm_post.j  in the old format.