### PR TITLE
Enable LOPEZ lightning scheme

### DIFF
--- a/src/Applications/GEOSctm_App/GEOSCTM.rc.tmpl
+++ b/src/Applications/GEOSctm_App/GEOSCTM.rc.tmpl
@@ -1,3 +1,5 @@
+# GEOS-CTM resource file, modeled after AGCM.rc
+SimType: CTM
 
 # Atmospheric Model Configuration Parameters
 # ------------------------------------------

--- a/src/Applications/GEOSctm_App/MERRA2_ExtData.rc.tmpl
+++ b/src/Applications/GEOSctm_App/MERRA2_ExtData.rc.tmpl
@@ -21,7 +21,9 @@ SGH         'm'              Y        N           0                 0.0      1.0
 FRACI       '1'              N        N           0                 0.0      1.0     FRSEAICE     /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_flx_Nx.%y4%m2%d2.nc4
 ZPBL        'm'              N        N           0                 0.0      1.0     PBLH         /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_flx_Nx.%y4%m2%d2.nc4
 PPBL        'Pa'             N        N           0                 0.0      1.0     PBLTOP       /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_slv_Nx.%y4%m2%d2.nc4
+ZLCL        'm'              N        N           0                 0.0      1.0     ZLCL         /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_slv_Nx.%y4%m2%d2.nc4
 PRECCON     'kg m-2 s-1'     N        N           0                 0.0      1.0     PRECCON      /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_flx_Nx.%y4%m2%d2.nc4
+PRECTOT     'kg m-2 s-1'     N        N           0                 0.0      1.0     PRECTOTCORR  /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_flx_Nx.%y4%m2%d2.nc4
 PRECANV     'kg m-2 s-1'     N        N           0                 0.0      1.0     PRECANV      /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_flx_Nx.%y4%m2%d2.nc4
 PRECLSC     'kg m-2 s-1'     N        N           0                 0.0      1.0     PRECLSC      /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_flx_Nx.%y4%m2%d2.nc4
 CN_PRCP     'kg m-2 s-1'     N        N           0                 0.0      1.0     PRECCON      /discover/nobackup/projects/gmao/merra2/data/products/MERRA2_all/Y%y4/M%m2/MERRA2.tavg1_2d_flx_Nx.%y4%m2%d2.nc4

--- a/src/Applications/GEOSctm_App/MERRA2_ExtData.yaml.tmpl
+++ b/src/Applications/GEOSctm_App/MERRA2_ExtData.yaml.tmpl
@@ -39,6 +39,8 @@ Exports:
   FRACI:      { variable: FRSEAICE,      collection: TAVG1_2D_FLX_NX,      regrid: BILINEAR,   sample: MERRA2.timestep }
   ZPBL:       { variable: PBLH,          collection: TAVG1_2D_FLX_NX,      regrid: BILINEAR,   sample: MERRA2.timestep }
   PPBL:       { variable: PBLTOP,        collection: TAVG1_2D_SLV_NX,      regrid: BILINEAR,   sample: MERRA2.timestep }
+  ZLCL:       { variable: ZLCL,          collection: TAVG1_2D_SLV_NX,      regrid: BILINEAR,   sample: MERRA2.timestep }
+  PRECTOT:    { variable: PRECTOTCORR,   collection: TAVG1_2D_FLX_NX,      regrid: BILINEAR,   sample: MERRA2.timestep }
   PRECCON:    { variable: PRECCON,       collection: TAVG1_2D_FLX_NX,      regrid: BILINEAR,   sample: MERRA2.timestep }
   PRECANV:    { variable: PRECANV,       collection: TAVG1_2D_FLX_NX,      regrid: BILINEAR,   sample: MERRA2.timestep }
   PRECLSC:    { variable: PRECLSC,       collection: TAVG1_2D_FLX_NX,      regrid: BILINEAR,   sample: MERRA2.timestep }

--- a/src/Applications/GEOSctm_App/README
+++ b/src/Applications/GEOSctm_App/README
@@ -1,4 +1,4 @@
-As of Apr 10, 2025:
+As of Apr 17, 2025:
 
 Requires modifications in these repo's:
 
@@ -10,6 +10,11 @@ Requires modifications in these repo's:
   GOCART :
     pushd src/Components/GEOSctm_GridComp/@GEOSchem_GridComp/@GOCART/
     git merge remotes/origin/feature/mmanyin/update_for_CTM
+    popd
+
+  CHEM :
+    pushd src/Components/GEOSctm_GridComp/@GEOSchem_GridComp/
+    git merge remotes/origin/feature/mmanyin/lightning_update
     popd
 
 TR will work w/ the default options in ctm_setup
@@ -26,13 +31,9 @@ Sections of the run-script are not needed, but they are kept
 for the convenience of comparison with GCM.  They are skipped
 by the addition of simple 'goto' statements.
 
-ChemEnv runs the LOPEZ lightning scheme by default, and a few imports
-that are available in the GCM context are not available from MERRA2.
-For now we set ChemEnv to use the MOIST scheme instead.
-The CHEM code still tries to import the missing fields, so
+ChemEnv imports a few fields that are not available in the CTM context, so
 NULL imports are quietly added in the run-script; search for
 'Until ChemEnv accounts for Imports'
-
 
 GOCART includes the hard-coded filename "AGCM.rc" .
 The run-script makes a link of that name; search for
@@ -58,5 +59,6 @@ optics filenames are appended to GEOSCTM.rc
 
 HEMCO:
 If GOCART2G is running, even if it's in DATA DRIVEN mode, HEMCO
-still needs to be running the GOCART2G instance, because
-CHEM adds a connectivity.
+still needs to be running the GOCART2G instance, because CHEM cannot tell
+what mode GOCART2G is running in, so it adds a HEMCO->GOCART2G connectivity
+whether it's needed or not.

--- a/src/Applications/GEOSctm_App/ctm_run.j
+++ b/src/Applications/GEOSctm_App/ctm_run.j
@@ -292,8 +292,6 @@ ln -s GEOSCTM.rc AGCM.rc
 ### rc
 set NULL_CAPE  = "CAPE             '1'            N   Y   -                        none    none  UNUSED            /dev/null"
 set NULL_INHB  = "INHB             '1'            N   Y   -                        none    none  UNUSED            /dev/null"
-set NULL_PREC  = "PRECTOT          '1'            N   Y   -                        none    none  UNUSED            /dev/null"
-set NULL_ZLCL  = "ZLCL             '1'            N   Y   -                        none    none  UNUSED            /dev/null"
 set NULL_ZLFC  = "ZLFC             '1'            N   Y   -                        none    none  UNUSED            /dev/null"
 
 # Add the lines to this file, after the line that includes 'MCOR'
@@ -304,18 +302,12 @@ cat           TempFile | sed -e "/MCOR/a $NULL_CAPE" > $file
 /bin/mv $file TempFile
 cat           TempFile | sed -e "/MCOR/a $NULL_INHB" > $file
 /bin/mv $file TempFile
-cat           TempFile | sed -e "/MCOR/a $NULL_PREC" > $file
-/bin/mv $file TempFile
-cat           TempFile | sed -e "/MCOR/a $NULL_ZLCL" > $file
-/bin/mv $file TempFile
 cat           TempFile | sed -e "/MCOR/a $NULL_ZLFC" > $file
 /bin/rm TempFile
 
 ### yaml
 set NULL_CAPE  = "\ \ CAPE:"
 set NULL_INHB  = "\ \ INHB:"
-set NULL_PREC  = "\ \ PRECTOT:"
-set NULL_ZLCL  = "\ \ ZLCL:"
 set NULL_ZLFC  = "\ \ ZLFC:"
 set NULL_NULL  = "\ \ \ \ collection: /dev/null"
 
@@ -330,14 +322,6 @@ cat           TempFile | sed -e "/Exports/a $NULL_CAPE" > $file
 cat           TempFile | sed -e "/Exports/a $NULL_NULL" > $file
 /bin/mv $file TempFile
 cat           TempFile | sed -e "/Exports/a $NULL_INHB" > $file
-/bin/mv $file TempFile
-cat           TempFile | sed -e "/Exports/a $NULL_NULL" > $file
-/bin/mv $file TempFile
-cat           TempFile | sed -e "/Exports/a $NULL_PREC" > $file
-/bin/mv $file TempFile
-cat           TempFile | sed -e "/Exports/a $NULL_NULL" > $file
-/bin/mv $file TempFile
-cat           TempFile | sed -e "/Exports/a $NULL_ZLCL" > $file
 /bin/mv $file TempFile
 cat           TempFile | sed -e "/Exports/a $NULL_NULL" > $file
 /bin/mv $file TempFile

--- a/src/Applications/GEOSctm_App/ctm_setup
+++ b/src/Applications/GEOSctm_App/ctm_setup
@@ -3349,11 +3349,11 @@ else if ( $ctmGMI == TRUE ) then
       /bin/mv -f $EXPDIR/RC/GMI_GridComp.tmp $EXPDIR/RC/GMI_GridComp.rc
     endif
 
-# Use MOIST scheme for lightning, until LOPEZ is supported
-# --------------------------------------------------------
+# Fields like LFC are not available from ExtData nor CTMenv at this point
+# -----------------------------------------------------------------------
     /bin/mv $EXPDIR/RC/ChemEnv.rc $EXPDIR/RC/ChemEnv.tmp
     cat $EXPDIR/RC/ChemEnv.tmp | \
-    awk '{ if ($1~"flashSource:") { sub(/LOPEZ/,"MOIST") }; print }' > $EXPDIR/RC/ChemEnv.rc
+    awk '{ if ($1~"useImportedCape:") { sub(/TRUE/,"FALSE") }; print }' > $EXPDIR/RC/ChemEnv.rc
     /bin/rm $EXPDIR/RC/ChemEnv.tmp
 
 # Turn on GEOS-Chem


### PR DESCRIPTION
Lightning provides NOx emissions in GMI. The default LOPEZ scheme is now restored to working order in CTM.
The Passive Tracer and Idealized Tracer modes are zero-diff.

Three repo's need updates, after 'mepo clone':

  FVdycoreCubed_GridComp  (PR #301):
    pushd src/Components/GEOSctm_GridComp/@FVdycoreCubed_GridComp/
    git merge remotes/origin/feature/mmanyin/update_for_CTM
    popd

  GOCART :
    pushd src/Components/GEOSctm_GridComp/@GEOSchem_GridComp/@GOCART/
    git merge remotes/origin/feature/mmanyin/update_for_CTM
    popd

  CHEM :
    pushd src/Components/GEOSctm_GridComp/@GEOSchem_GridComp/
    git merge remotes/origin/feature/mmanyin/lightning_update
    popd